### PR TITLE
chore: improve launching with localhost

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 export FLASK_APP=flask_app.py
-flask run
+flask run -p 4999

--- a/launch.sh
+++ b/launch.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 export FLASK_APP=flask_app.py
+export FLASK_DEBUG=1
 flask run -p 4999


### PR DESCRIPTION
When running Vatayana locally, there were two annoying problems that could both be fixed by modifying the commands in the `launch.sh` bash script:

1. macOS began using port 5000 for `Airplay Receiver` starting with Monterey (late 2021). But so does Flask by default. This causes sporadic authentication problems ("Access to localhost is denied"). I do use AirPlay, so I switched to port 4999 for this app.
2. I had to restart the server every time I wanted to see new changes to even HTML templates. I thought that setting `app.config["DEBUG"] = True` in `flask_app.py` would be enough to enable the handy debugging mode with auto-reloading, but apparently it's not. Exporting `FLASK_DEBUG=1` in the bash script makes the difference.