### PR TITLE
feat: add easy-to-use dropdowns to select text and specific doc_id

### DIFF
--- a/IR_tools.py
+++ b/IR_tools.py
@@ -5,7 +5,7 @@ import re
 import math
 import numpy as np
 
-from collections import OrderedDict, Counter
+from collections import OrderedDict, Counter, defaultdict
 from fastdist import fastdist
 from string import Template
 from tqdm import tqdm
@@ -219,6 +219,13 @@ text_abbrev2fn = load_dict_from_json("assets/text_abbreviations_IASTreduced.json
 text_abbrev2title = load_dict_from_json("assets/text_abbreviations.json") # for human eyes
 # e.g. text_abbrev2fn[TEXT_ABBRV] = STRING
 # don't sort these yet because they're in chronological order for presenting prioritization options
+
+# create lookup table of local_doc_ids by text abbreviation
+abbrv2docs = defaultdict(lambda:[])
+for doc_id in doc_ids:
+    first_underscore = doc_id.find('_')
+    abbrv, local_doc_id = doc_id[:first_underscore], doc_id[first_underscore+1:]
+    abbrv2docs[abbrv].append(local_doc_id)
 
 # save fresh corpus text list to file
 corpus_texts_list_relative_path_fn = 'assets/corpus_texts.txt'

--- a/flask_app.py
+++ b/flask_app.py
@@ -96,12 +96,15 @@ def doc_explore():
 
     ensure_keys()
 
-    if request.method == "POST" or 'doc_id' in request.args:
+    if request.method == "POST" or 'text_abbrv' in request.args or 'doc_id' in request.args:
 
-        if 'doc_id' in request.form:
-            doc_id = request.form.get("doc_id")
-        elif 'doc_id' in request.args:
+
+        if 'doc_id' in request.args:
             doc_id = request.args.get("doc_id")
+        else:
+            text_abbreviation_input = request.form.get("text_abbreviation_input")
+            local_doc_id_input = request.form.get("local_doc_id_input")
+            doc_id = text_abbreviation_input + '_' + local_doc_id_input
 
         valid_doc_ids = IR_tools.doc_ids
         if doc_id in valid_doc_ids:
@@ -127,7 +130,10 @@ def doc_explore():
         return render_template(    "docExplore.html",
                                 page_subtitle="docExplore",
                                 doc_id=doc_id,
-                                docExploreInner_HTML=docExploreInner_HTML
+                                docExploreInner_HTML=docExploreInner_HTML,
+                                abbrv2docs=IR_tools.abbrv2docs,
+                                text_abbrev2title=IR_tools.text_abbrev2title,
+                                section_labels=IR_tools.section_labels,
                                 )
 
     else: # request.method == "GET" or URL query malformed
@@ -135,7 +141,10 @@ def doc_explore():
         return render_template(    "docExplore.html",
                                 page_subtitle="docExplore",
                                 doc_id="",
-                                doc_explore_output=""
+                                doc_explore_output="",
+                                abbrv2docs=IR_tools.abbrv2docs,
+                                text_abbrev2title=IR_tools.text_abbrev2title,
+                                section_labels=IR_tools.section_labels,
                                 )
 
 @app.route('/docCompare', methods=["GET", "POST"])
@@ -185,7 +194,10 @@ def doc_compare():
                                 doc_id_2=doc_id_2,
                                 activate_similar_link_buttons_left=sim_btn_left,
                                 activate_similar_link_buttons_right=sim_btn_right,
-                                docCompareInner_HTML=docCompareInner_HTML
+                                docCompareInner_HTML=docCompareInner_HTML,
+                                abbrv2docs=IR_tools.abbrv2docs,
+                                text_abbrev2title=IR_tools.text_abbrev2title,
+                                section_labels=IR_tools.section_labels,
                                 )
 
     else: # request.method == "GET" or URL query malformed
@@ -194,7 +206,10 @@ def doc_compare():
                                 page_subtitle="docCompare",
                                 doc_id_1="",
                                 doc_id_2="",
-                                doc_explore_output=""
+                                doc_explore_output="",
+                                abbrv2docs=IR_tools.abbrv2docs,
+                                text_abbrev2title=IR_tools.text_abbrev2title,
+                                section_labels=IR_tools.section_labels,
                                 )
 
 @app.route('/textView', methods=["GET", "POST"])

--- a/flask_app.py
+++ b/flask_app.py
@@ -152,22 +152,25 @@ def doc_compare():
 
     ensure_keys()
 
-    if request.method == "POST" or 'doc_id_1' in request.args:
+    if request.method == "POST" or 'text_abbrv' in request.args or 'doc_id_1' in request.args:
 
         doc_id_1 = doc_id_2 = ""
-        if 'doc_id_1' in request.form:
-            doc_id_1 = request.form.get("doc_id_1")
-            doc_id_2 = request.form.get("doc_id_2")
-        elif 'doc_id_1' in request.args:
+        if 'doc_id_1' in request.args:
             doc_id_1 = request.args.get("doc_id_1")
             doc_id_2 = request.args.get("doc_id_2")
+        else:
+            text_abbreviation_input_1 = request.form.get("text_abbreviation_input_1")
+            local_doc_id_input_1 = request.form.get("local_doc_id_input_1")
+            doc_id_1 = text_abbreviation_input_1 + '_' + local_doc_id_input_1
+            text_abbreviation_input_2 = request.form.get("text_abbreviation_input_2")
+            local_doc_id_input_2 = request.form.get("local_doc_id_input_2")
+            doc_id_2 = text_abbreviation_input_2 + '_' + local_doc_id_input_2
 
         valid_doc_ids = IR_tools.doc_ids
         sim_btn_left = sim_btn_right = ""
         if doc_id_1 == doc_id_2:
-            output_HTML = "<br><p>Those are the same, please enter two different doc ids to compare.</p>"
+            docCompareInner_HTML = "<br><p>Those are the same, please enter two different doc ids to compare.</p>"
         elif doc_id_1 in valid_doc_ids and doc_id_2 in valid_doc_ids:
-            # output_HTML = "<br><p>Good, those are valid.</p>"
 
             auto_reweight_topics_option = False
             if auto_reweight_topics_option:

--- a/flask_app.py
+++ b/flask_app.py
@@ -234,7 +234,8 @@ def text_view():
                                 text_abbreviation=text_abbreviation_input,
                                 local_doc_id=local_doc_id_input,
                                 text_title=text_title,
-                                text_HTML=text_HTML
+                                text_HTML=text_HTML,
+                                abbrv2docs=IR_tools.abbrv2docs,
                                 )
 
     else: # request.method == "GET" or no URL params
@@ -244,7 +245,8 @@ def text_view():
                                 text_abbreviation="",
                                 local_doc_id="",
                                 text_title="",
-                                text_HTML=""
+                                text_HTML="",
+                                abbrv2docs=IR_tools.abbrv2docs,
                                 )
 
 @app.route('/BrucheionAlign')

--- a/flask_app.py
+++ b/flask_app.py
@@ -236,6 +236,8 @@ def text_view():
                                 text_title=text_title,
                                 text_HTML=text_HTML,
                                 abbrv2docs=IR_tools.abbrv2docs,
+                                text_abbrev2title=IR_tools.text_abbrev2title,
+                                section_labels=IR_tools.section_labels,
                                 )
 
     else: # request.method == "GET" or no URL params
@@ -247,6 +249,8 @@ def text_view():
                                 text_title="",
                                 text_HTML="",
                                 abbrv2docs=IR_tools.abbrv2docs,
+                                text_abbrev2title=IR_tools.text_abbrev2title,
+                                section_labels=IR_tools.section_labels,
                                 )
 
 @app.route('/BrucheionAlign')

--- a/templates/docCompare.html
+++ b/templates/docCompare.html
@@ -83,23 +83,52 @@
 
 				<form id="doc_compare_search_bar" action="/docCompare" method="POST">
 
-				<div class="col-md-3">
-		            <input id="doc_id_1" name="doc_id_1" type="text" class="form-control" placeholder="Enter doc id 1" value="{{ doc_id_1 }}" size="30"/>
-		        </div>
+<!--				<div class="col-md-3">-->
+<!--		            <input id="doc_id_1" name="doc_id_1" type="text" class="form-control" placeholder="Enter doc id 1" value="{{ doc_id_1 }}" size="30"/>-->
+<!--		        </div>-->
 
-		        <div class="col-md-3">
-			    </div>
+<!--		        <div class="col-md-3">-->
+<!--			    </div>-->
 
-		    	<div class="col-md-3">
-		            <input id="doc_id_2" name="doc_id_2" type="text" class="form-control" placeholder="Enter doc id 2" value="{{ doc_id_2 }}" size="30"/>
-		        </div>
+<!--		    	<div class="col-md-3">-->
+<!--		            <input id="doc_id_2" name="doc_id_2" type="text" class="form-control" placeholder="Enter doc id 2" value="{{ doc_id_2 }}" size="30"/>-->
+<!--		        </div>-->
 
-		        <div class="col-md-1">
-			    </div>
+<!--		        <div class="col-md-1">-->
+<!--			    </div>-->
 
-		        <div class="col-md-2">
-		            <input id="doc_compare_search_submit_button" type="submit" class="btn btn-block btn-primary" value="Submit"/>
-			    </div>
+<!--		        <div class="col-md-2">-->
+<!--		            <input id="doc_compare_search_submit_button" type="submit" class="btn btn-block btn-primary" value="Submit"/>-->
+<!--			    </div>-->
+
+					<!-- input -->
+					<div class="row">
+						<div class="col-md-2">
+							<select name="text_abbreviation_input_1" id="text_abbreviation_input_1" class="form-control">
+								<option value="{{ text_abbreviation_1 }}" size="15" selected="selected">Select text</option>
+							</select>
+						</div>
+						<div class="col-md-3">
+							<select name="local_doc_id_input_1" id="local_doc_id_input_1" class="form-control">
+								<option value="{{ local_doc_id_1 }}" size="15" selected="selected">Select doc id</option>
+							</select>
+						</div>
+						<div class="col-md-1">
+						</div>
+						<div class="col-md-2">
+							<select name="text_abbreviation_input_2" id="text_abbreviation_input_2" class="form-control">
+								<option value="{{ text_abbreviation_2 }}" size="15" selected="selected">Select text</option>
+							</select>
+						</div>
+						<div class="col-md-3">
+							<select name="local_doc_id_input_2" id="local_doc_id_input_2" class="form-control">
+								<option value="{{ local_doc_id_2 }}" size="15" selected="selected">Select doc id</option>
+							</select>
+						</div>
+						<div class="col-md-1">
+							<input id="doc_compare_submit_button" type="submit" class="btn btn-block btn-primary" value="Submit"/>
+						</div>
+					</div>
 
 			    </form>
 
@@ -125,6 +154,38 @@
          	window.onload = function() {
                 conditionally_display_similar_doc_link_buttons();
             }
+
+			var abbrv2docs = {{ abbrv2docs|tojson|safe }};
+			var abbrev2title = {{ text_abbrev2title|tojson|safe }};
+			var section_labels = {{ section_labels|tojson|safe }};
+
+			var textAbbrevSel_1 = document.getElementById("text_abbreviation_input_1");
+			var docIdSel_1 = document.getElementById("local_doc_id_input_1");
+			textAbbrevSel_1.length = 1;
+			for (var x in abbrv2docs) {
+				textAbbrevSel_1.options[textAbbrevSel_1.options.length] = new Option(x + ' ' + abbrev2title[x], x);
+			}
+			textAbbrevSel_1.onchange = function() {
+				docIdSel_1.length = 1;
+				for (var y of abbrv2docs[this.value]) {
+				  docIdSel_1.options[docIdSel_1.options.length] = new Option(y + ' ' + section_labels[this.value + '_' + y], y);
+				}
+			}
+
+			var textAbbrevSel_2 = document.getElementById("text_abbreviation_input_2");
+			var docIdSel_2 = document.getElementById("local_doc_id_input_2");
+			textAbbrevSel_2.length = 1;
+			for (var x in abbrv2docs) {
+				textAbbrevSel_2.options[textAbbrevSel_2.options.length] = new Option(x + ' ' + abbrev2title[x], x);
+			}
+			textAbbrevSel_2.onchange = function() {
+				docIdSel_2.length = 1;
+				for (var y of abbrv2docs[this.value]) {
+				  docIdSel_2.options[docIdSel_2.options.length] = new Option(y + ' ' + section_labels[this.value + '_' + y], y);
+				}
+			}
+
+    </script>
         </script>
 
     </body>

--- a/templates/docExplore.html
+++ b/templates/docExplore.html
@@ -84,12 +84,22 @@
         	
 			<form id="doc_explore_search_bar" action="/docExplore" method="POST">
 
+				<!-- input -->
 			    <div class="row">
-			    	<div class="col-md-3">
-			            <input id="doc_id" name="doc_id" type="text" class="form-control" placeholder="Enter doc id" size="30"/>
+			    	<div class="col-md-2">
+<!--			            <input id="doc_id" name="doc_id" type="text" class="form-control" placeholder="Enter doc id" size="30"/>-->
+						<select name="text_abbreviation_input" id="text_abbreviation_input" class="form-control">
+							<option value="{{ text_abbreviation }}" size="15" selected="selected">Select text</option>
+						</select>
 			        </div>
-			        <div class="col-md-2">
+					<div class="col-md-3">
+						<select name="local_doc_id_input" id="local_doc_id_input" class="form-control">
+							<option value="{{ local_doc_id }}" size="15" selected="selected">Select doc id (optional)</option>
+						</select>
+			        </div>
+			        <div class="col-md-1">
 			            <input id="doc_explore_submit_button" type="submit" class="btn btn-block btn-primary" value="Submit"/>
+
 			        </div>
 			    </div>
 
@@ -109,5 +119,24 @@
 	</script>
 
     </body>
+
+	<script type="text/javascript">
+    	var abbrv2docs = {{ abbrv2docs|tojson|safe }};
+    	var abbrev2title = {{ text_abbrev2title|tojson|safe }};
+    	var section_labels = {{ section_labels|tojson|safe }};
+
+		var textAbbrevSel = document.getElementById("text_abbreviation_input");
+		var docIdSel = document.getElementById("local_doc_id_input");
+		textAbbrevSel.length = 1;
+		for (var x in abbrv2docs) {
+			textAbbrevSel.options[textAbbrevSel.options.length] = new Option(x + ' ' + abbrev2title[x], x);
+		}
+		textAbbrevSel.onchange = function() {
+			docIdSel.length = 1;
+			for (var y of abbrv2docs[this.value]) {
+			  docIdSel.options[docIdSel.options.length] = new Option(y + ' ' + section_labels[this.value + '_' + y], y);
+			}
+		}
+    </script>
 
 </html>

--- a/templates/docExplore.html
+++ b/templates/docExplore.html
@@ -94,7 +94,7 @@
 			        </div>
 					<div class="col-md-3">
 						<select name="local_doc_id_input" id="local_doc_id_input" class="form-control">
-							<option value="{{ local_doc_id }}" size="15" selected="selected">Select doc id (optional)</option>
+							<option value="{{ local_doc_id }}" size="15" selected="selected">Select doc id</option>
 						</select>
 			        </div>
 			        <div class="col-md-1">

--- a/templates/textView.html
+++ b/templates/textView.html
@@ -85,7 +85,7 @@
 	                    
 	                    <!-- <input id="text_abbreviation_input" name="text_abbreviation_input" type="text" class="form-control" placeholder="Enter text abbreviation here" value="{{ text_abbreviation }}" size="30"/> -->
 
-						<select name="text_abbreviation_input" id="text_abbreviation_input">
+						<select name="text_abbreviation_input" id="text_abbreviation_input" class="form-control">
 							<option value="{{ text_abbreviation }}" size="30" selected="selected">Select text</option>
 						</select>
 
@@ -94,8 +94,8 @@
 
 	                    <!-- <input id="local_doc_id_input" name="local_doc_id_input" type="text" class="form-control" placeholder="Enter doc id here" value="{{ local_doc_id }}" size="30"/> -->
 
-						<select name="local_doc_id_input" id="local_doc_id_input">
-							<option value="{{ local_doc_id }}" size="30" selected="selected">Select doc id</option>
+						<select name="local_doc_id_input" id="local_doc_id_input" class="form-control">
+							<option value="{{ local_doc_id }}" size="30" selected="selected">Select doc id (optional)</option>
 						</select>
 
 	                </div>
@@ -118,15 +118,19 @@
 
     <script type="text/javascript">
     	var abbrv2docs = {{ abbrv2docs|tojson|safe }};
+    	var abbrev2title = {{ text_abbrev2title|tojson|safe }};
+    	var section_labels = {{ section_labels|tojson|safe }};
+
 		var textAbbrevSel = document.getElementById("text_abbreviation_input");
 		var docIdSel = document.getElementById("local_doc_id_input");
+		textAbbrevSel.length = 1;
 		for (var x in abbrv2docs) {
-			textAbbrevSel.options[textAbbrevSel.options.length] = new Option(x, x);
+			textAbbrevSel.options[textAbbrevSel.options.length] = new Option(x + ' ' + abbrev2title[x], x);
 		}
 		textAbbrevSel.onchange = function() {		    
 			docIdSel.length = 1;
 			for (var y of abbrv2docs[this.value]) {
-			  docIdSel.options[docIdSel.options.length] = new Option(y, y);
+			  docIdSel.options[docIdSel.options.length] = new Option(y + ' ' + section_labels[this.value + '_' + y], y);
 			}
 		}
     </script>

--- a/templates/textView.html
+++ b/templates/textView.html
@@ -82,11 +82,24 @@
 				<!-- input -->
                 <div class="row">
                 	<div class="col-md-3">
-	                    <input id="text_abbreviation_input" name="text_abbreviation_input" type="text" class="form-control" placeholder="Enter text abbreviation here" value="{{ text_abbreviation }}" size="30"/>
+	                    
+	                    <!-- <input id="text_abbreviation_input" name="text_abbreviation_input" type="text" class="form-control" placeholder="Enter text abbreviation here" value="{{ text_abbreviation }}" size="30"/> -->
+
+						<select name="text_abbreviation_input" id="text_abbreviation_input">
+							<option value="{{ text_abbreviation }}" size="30" selected="selected">Select text</option>
+						</select>
+
 	                </div>
 	                <div class="col-md-3">
-	                    <input id="local_doc_id_input" name="local_doc_id_input" type="text" class="form-control" placeholder="Enter doc id here" value="{{ local_doc_id }}" size="30"/>
+
+	                    <!-- <input id="local_doc_id_input" name="local_doc_id_input" type="text" class="form-control" placeholder="Enter doc id here" value="{{ local_doc_id }}" size="30"/> -->
+
+						<select name="local_doc_id_input" id="local_doc_id_input">
+							<option value="{{ local_doc_id }}" size="30" selected="selected">Select doc id</option>
+						</select>
+
 	                </div>
+
 	                <div class="col-md-2">
 		                <input id="text_view_submit_button" type="submit" class="btn btn-block btn-primary" value="Submit"/>
 		            </div>
@@ -102,5 +115,20 @@
 
 
     </body>
+
+    <script type="text/javascript">
+    	var abbrv2docs = {{ abbrv2docs|tojson|safe }};
+		var textAbbrevSel = document.getElementById("text_abbreviation_input");
+		var docIdSel = document.getElementById("local_doc_id_input");
+		for (var x in abbrv2docs) {
+			textAbbrevSel.options[textAbbrevSel.options.length] = new Option(x, x);
+		}
+		textAbbrevSel.onchange = function() {		    
+			docIdSel.length = 1;
+			for (var y of abbrv2docs[this.value]) {
+			  docIdSel.options[docIdSel.options.length] = new Option(y, y);
+			}
+		}
+    </script>
 
 </html>

--- a/templates/textView.html
+++ b/templates/textView.html
@@ -81,7 +81,7 @@
 
 				<!-- input -->
                 <div class="row">
-                	<div class="col-md-3">
+                	<div class="col-md-2">
 	                    
 	                    <!-- <input id="text_abbreviation_input" name="text_abbreviation_input" type="text" class="form-control" placeholder="Enter text abbreviation here" value="{{ text_abbreviation }}" size="30"/> -->
 
@@ -100,7 +100,7 @@
 
 	                </div>
 
-	                <div class="col-md-2">
+	                <div class="col-md-1">
 		                <input id="text_view_submit_button" type="submit" class="btn btn-block btn-primary" value="Submit"/>
 		            </div>
                 </div>


### PR DESCRIPTION
See #1.

This PR adds the necessary backend objects in `IR_tools.py` for presenting the list of human-readable text names and the filtering all possible doc ids by the user's selection, as well as the front-end dropdown menus themselves to replace the free-text entry boxes in the forms on `textView`, `docExplore`, and `docCompare`.