### PR TITLE
chore: add requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# JetBrains IDEs
+.idea/


### PR DESCRIPTION
Generated `requirements.txt` with `pip-compile` from `requirements.in`. Tested in virtualenv (based on Python 3.9) to make sure all sub-dependencies covered.

Also ignore JetBrains folder.