### PR TITLE
feat: enable in-app batch mode

### DIFF
--- a/IR_tools.py
+++ b/IR_tools.py
@@ -682,9 +682,9 @@ def format_textView_link(doc_id):
     work_abbrv, local_doc_id = parse_complex_doc_id(doc_id)
     return "<a href='textView?text_abbrv=%s#%s' target='textView%s'>txtVw</a>" % (work_abbrv, local_doc_id, work_abbrv)
 
-def format_docCompare_link(doc_id_1, doc_id_2):
-    # each one looks like fixed string "dcCp"
-    return "<a href='docCompare?doc_id_1=%s&doc_id_2=%s' target='docCompare'>dcCp</a>" % (doc_id_1, doc_id_2)
+def format_docCompare_link(doc_id_1, doc_id_2, display_string="dcCp"):
+    # each one looks like fixed string "dcCp" unless otherwise specified
+    return "<a href='docCompare?doc_id_1=%s&doc_id_2=%s' target='docCompare'>%s</a>" % (doc_id_1, doc_id_2, display_string)
 
 def format_similarity_result_columns(query_id, priority_results_list_content, secondary_results_list_content):
 
@@ -1252,9 +1252,10 @@ def batch_mode(similarity_data, query_doc_id_start, query_doc_id_end) -> List[Di
 def format_batch_results(results, doc_id_1, doc_id_2):
     # begin with head of table
     table_header_HTML = """
-                    <h1 align="center">Similar Documents for {}</h1>""".format(
+                    <h1 align="center">Similarity Search Results for {}</h1>""".format(
         '{} – {}'.format(doc_id_1, doc_id_2)
     )
+    table_header_HTML += "<br>"
     table_header_HTML += """
         <table id="batch_result_table" class="display">
           <thead>
@@ -1266,18 +1267,16 @@ def format_batch_results(results, doc_id_1, doc_id_2):
               <th>{}</th>
               <th>{}</th>
               <th>{}</th>
-              <th>{}</th>
             </tr>
           </thead>
           <tbody>
     """.format('rank',
-               'doc_id_1',
-               'doc_id_2',
+               'query doc id',
+               'comparison doc id',
                'topic',
-               'tf-idf',
-               'sw',
-               'text of best match (doc 1)',
-               'dcCp url'
+               'vocab',
+               'phrase',
+               'phrase match (as in query doc)',
                )
 
     # format rows
@@ -1315,8 +1314,7 @@ def format_batch_result_rows(results: List[Dict[str, Union[str, float]]]):
               <td>{:.1%}</td>
               <td>{:.1%}</td>
               <td>{}</td>
-              <td></td>
-              <td></td>
+              <td>{}</td>
             </tr>
         """.format(
             i+1,
@@ -1325,6 +1323,7 @@ def format_batch_result_rows(results: List[Dict[str, Union[str, float]]]):
             result['topic'],
             result['tf_idf'],
             result['sw_w'],
+            format_docCompare_link(result['query_id'], result['doc_id_2'], "test"),
         )
     return HTML_rows
 

--- a/IR_tools.py
+++ b/IR_tools.py
@@ -1203,7 +1203,12 @@ def get_closest_docs(   query_id,
     return results_HTML
 
 
-def batch_mode(similarity_data, query_doc_id_start, query_doc_id_end) -> List[Dict[str, Union[str, float]]]:
+def batch_mode(
+        similarity_data,
+        query_doc_id_start,
+        query_doc_id_end,
+        sw_score_threshold,
+) -> List[Dict[str, Union[str, float]]]:
     query_doc_id_range = range(doc_ids.index(query_doc_id_start), doc_ids.index(query_doc_id_end) + 1)
     query_doc_ids = [doc_ids[i] for i in query_doc_id_range]
 
@@ -1227,12 +1232,11 @@ def batch_mode(similarity_data, query_doc_id_start, query_doc_id_end) -> List[Di
     sorted_records_dict = {k: records_dict[k] for k in ks}
     print("sort records:", calc_dur(start2, datetime.now().time()))
 
-    sw_w_min_threshold = 30
     start3 = datetime.now().time()
     best_results: List[Dict[str, Union[str, float]]] = []
     for doc_id, similar_docs in sorted_records_dict.items():
         for doc_id_2, sw_score in similar_docs['sw_w'].items():
-            if sw_score >= sw_w_min_threshold:
+            if sw_score >= int(sw_score_threshold):
                 best_results.append({
                     'query_id': doc_id,
                     'doc_id_2': doc_id_2,

--- a/IR_tools.py
+++ b/IR_tools.py
@@ -783,8 +783,8 @@ def truncate_dict(dictionary: Dict, n: int) -> Dict:
         for (k, v) in list(dictionary.items())[:n]
     }
 
-N_TDIDF_SAVE_LIMIT=4000
-N_SW_SAVE_LIMIT=200
+N_TDIDF_SAVE_LIMIT = 4000
+N_SW_SAVE_LIMIT = 200
 def get_closest_docs_with_db(
         similarity_data: PymongoCollection,
         query_id,
@@ -795,13 +795,15 @@ def get_closest_docs_with_db(
     # start = datetime.now().time()
     if not (
             record := similarity_data.find_one({"query_id": query_id})
-    ) or not (
-            len(topic_similar_docs := record["similar_docs"]["topic"]) != len(doc_ids)
+    # ) or not (
+    #         len(topic_similar_docs := record["similar_docs"]["topic"]) != len(doc_ids)
     ):
         # simply do from scratch
         similar_docs = calculate_similar_docs(query_id, N_tfidf, N_sw)
 
     else:
+        topic_similar_docs = rank_all_candidates_by_topic_similarity(query_id)
+
         # all topic comparisons done
 
         tf_idf_similar_docs = record["similar_docs"]["tf_idf"]
@@ -857,7 +859,7 @@ def get_closest_docs_with_db(
 
     # truncate what gets saved to prevent writing too much to db
     similar_docs_to_save = {
-        'topic': similar_docs['topic'],  # TODO: possibly drop? since biggest by far
+        # 'topic': similar_docs['topic'],  # dropped because too big
         'tf_idf': truncate_dict(similar_docs['tf_idf'], N_TDIDF_SAVE_LIMIT),
         'sw_w': truncate_dict(similar_docs['sw_w'], N_SW_SAVE_LIMIT),
     }

--- a/flask_app.py
+++ b/flask_app.py
@@ -116,6 +116,7 @@ def doc_explore():
         local_doc_id_input = ""
         local_doc_id_input_2 = ""
         doc_id_2 = ""
+        threshold = 30
 
         if 'doc_id' in request.args:
             doc_id = request.args.get("doc_id")
@@ -130,6 +131,11 @@ def doc_explore():
             local_doc_id_input_2 = request.form.get("local_doc_id_input_2")
             if local_doc_id_input_2 not in ['', None]:
                 doc_id_2 = text_abbreviation_input + '_' + local_doc_id_input_2
+
+        if 'threshold' in request.args:
+            sw_threshold = request.args.get("sw_threshold")
+        else:
+            sw_threshold = request.form.get("sw_threshold")
 
         valid_doc_ids = IR_tools.doc_ids
         if (
@@ -195,7 +201,7 @@ def doc_explore():
                 #   - also do text previews here? maybe those above certain threshold are saved?
                 # format result dict as HTML rows and return
 
-                best_results = IR_tools.batch_mode(similarity_data, doc_id, doc_id_2)
+                best_results = IR_tools.batch_mode(similarity_data, doc_id, doc_id_2, sw_threshold)
                 docExploreInner_HTML = IR_tools.format_batch_results(best_results, doc_id, doc_id_2)
 
             else:
@@ -211,7 +217,8 @@ def doc_explore():
                     similarity_data=similarity_data,
                     )
         else:
-            docExploreInner_HTML = "<br><p>Please enter valid doc ids like " + str(IR_tools.ex_doc_ids)[1:-1] + " etc.</p><p>See <a href='assets/doc_id_list.txt' target='_blank'>doc id list</a> and <a href='assets/corpus_texts.txt' target='_blank'>corpus text list</a> for hints to get started.</p>"
+            docExploreInner_HTML = "<br><p>Please verify sequence of two inputs.</p>"
+                                   # "Please enter valid doc ids like " + str(IR_tools.ex_doc_ids)[1:-1] + " etc.</p><p>See <a href='assets/doc_id_list.txt' target='_blank'>doc id list</a> and <a href='assets/corpus_texts.txt' target='_blank'>corpus text list</a> for hints to get started."
 
         return render_template(    "docExplore.html",
                                 page_subtitle="docExplore",

--- a/flask_app.py
+++ b/flask_app.py
@@ -150,75 +150,50 @@ def doc_explore():
             if doc_id_2 != "":
                 # batch mode
 
-                # begin with head of table
-                docExploreInner_HTML = """
-                <h1 align="center">Search Result for {}</h1>""".format(
-                    '{} – {}'.format(doc_id, doc_id_2)
-                )
-                docExploreInner_HTML += """
-                <table border="1px solid #dddddd;" width="100%">
-                  <thead>
-                    <tr align="center">
-                      <th width="10%">{}</th>
-                      <th width="10%">{}</th>
-                      <th width="5%">{}</th>
-                      <th width="5%">{}</th>
-                      <th width="5%">{}</th>
-                      <th width="25%">{}</th>
-                      <th width="5%">{}</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                """.format('doc_id_1',
-                           'doc_id_2',
-                           'topic',
-                           'tf-idf',
-                           'sw',
-                           'text of best match (doc 1)',
-                           'dcCp url'
-                           )
+                # first attempt: just piggy-back off of get_closest_docs()
+                # downside: one doc at a time
+
+                # docExploreInner_HTML += IR_tools.get_closest_docs(
+                #     query_id=IR_tools.doc_ids[i],
+                #     topic_weights=session['topic_weights'],
+                #     topic_labels=session['topic_labels'],
+                #     priority_texts=session["priority_texts"],
+                #     # topic_toggle_value=session["topic_toggle_value"]
+                #     N_tf_idf=session["N_tf_idf_" + session["search_depth_default"]],
+                #     N_sw_w=session["N_sw_w_" + session["search_depth_default"]],
+                #     similarity_data=similarity_data,
+                #     batch_mode=True,
+                # )
+
+                # second attempt: make special function to focus on batch mode
+                # but still one-at-a-time
 
                 # loop through all queries
                 # (possibly want to limit number of docs to e.g. 100 or 500)
-                for i in range(IR_tools.doc_ids.index(doc_id), IR_tools.doc_ids.index(doc_id_2)+1):
-                    # carry out query, get output in form of next batch of HTML rows
+                # for i in range(IR_tools.doc_ids.index(doc_id), IR_tools.doc_ids.index(doc_id_2)+1):
+                #     # carry out query, get output in form of next batch of HTML rows
+                #     docExploreInner_HTML += IR_tools.get_closest_docs_with_db_only_batch_only(
+                #         similarity_data,
+                #         query_id=doc_id,
+                #         sw_score_threshold=50,
+                #         priority_texts=session["priority_texts"],
+                #     )
 
-                    # what is actually necessary?
-                    # grab record (will always be available)
-                    #   - no, grab all at once
-                    #   - and maybe get scores at same time?
-                    #   - do NOT want 0.33 sec for EACH of grab, score, score
-                    # look through top few sw_w results until threshold exceeded
-                    #   - also filter at same time
-                    # construct result dict based on those doc_ids
-                    #   - topic not saved so calculate
-                    #   - also do text previews?
-                    # format result dict as HTML rows and return
-                    docExploreInner_HTML += IR_tools.get_closest_docs_with_db_only_batch_only(
-                        similarity_data,
-                        query_id=doc_id,
-                        sw_score_threshold=50,
-                        priority_texts=session["priority_texts"],
-                    )
+                # what is actually necessary?
+                # grab record (will always be available)
+                #   - do NOT want 0.33 sec for EACH of grab, score, score
+                #   - so instead grab ALL at once
+                #     - for now project to focus on more important scores
+                #     - will eventually change db schema to exclude topic data
+                # look through top few sw_w results until threshold exceeded
+                #   - also filter texts at same time
+                # construct result dict based on those doc_ids
+                #   - topic not saved so calculate
+                #   - also do text previews here? maybe those above certain threshold are saved?
+                # format result dict as HTML rows and return
 
-                # close off table
-                docExploreInner_HTML += """
-                  </tbody>
-                </table>
-                """
-
-
-                    # docExploreInner_HTML += IR_tools.get_closest_docs(
-                    #     query_id=IR_tools.doc_ids[i],
-                    #     topic_weights=session['topic_weights'],
-                    #     topic_labels=session['topic_labels'],
-                    #     priority_texts=session["priority_texts"],
-                    #     # topic_toggle_value=session["topic_toggle_value"]
-                    #     N_tf_idf=session["N_tf_idf_" + session["search_depth_default"]],
-                    #     N_sw_w=session["N_sw_w_" + session["search_depth_default"]],
-                    #     similarity_data=similarity_data,
-                    #     batch_mode=True,
-                    # )
+                best_results = IR_tools.batch_mode(similarity_data, doc_id, doc_id_2)
+                docExploreInner_HTML = IR_tools.format_batch_results(best_results, doc_id, doc_id_2)
 
             else:
                 # single-query mode

--- a/flask_app.py
+++ b/flask_app.py
@@ -109,8 +109,13 @@ def doc_explore():
 
     ensure_keys()
 
-    if request.method == "POST" or 'text_abbrv' in request.args or 'doc_id' in request.args:
+    if request.method == "POST" or 'doc_id' in request.args:
+        # NB: not yet supported is sending 'text_abbrv' and 'local_doc_id' via GET
 
+        text_abbreviation_input = ""
+        local_doc_id_input = ""
+        local_doc_id_input_2 = ""
+        doc_id_2 = ""
 
         if 'doc_id' in request.args:
             doc_id = request.args.get("doc_id")
@@ -119,13 +124,13 @@ def doc_explore():
             local_doc_id_input = request.form.get("local_doc_id_input")
             doc_id = text_abbreviation_input + '_' + local_doc_id_input
 
-        doc_id_2 = ""
         if 'doc_id_2' in request.args:
             doc_id_2 = request.args.get("doc_id_2")
         else:
-            text_abbreviation_input = request.form.get("text_abbreviation_input")
             local_doc_id_input_2 = request.form.get("local_doc_id_input_2")
-            if local_doc_id_input_2 != "":
+            if local_doc_id_input_2 is None:
+                local_doc_id_input_2 = ""
+            else:
                 doc_id_2 = text_abbreviation_input + '_' + local_doc_id_input_2
 
         valid_doc_ids = IR_tools.doc_ids
@@ -221,7 +226,7 @@ def doc_explore():
                                 section_labels=IR_tools.section_labels,
                                 )
 
-    else: # request.method == "GET" or URL query malformed
+    else: # request.method == "GET" and no arguments or URL query malformed
 
         return render_template(    "docExplore.html",
                                 page_subtitle="docExplore",
@@ -237,9 +242,8 @@ def doc_compare():
 
     ensure_keys()
 
-    if request.method == "POST" or 'text_abbrv' in request.args or 'doc_id_1' in request.args:
+    if request.method == "POST" or 'doc_id_1' in request.args:
 
-        doc_id_1 = doc_id_2 = ""
         if 'doc_id_1' in request.args:
             doc_id_1 = request.args.get("doc_id_1")
             doc_id_2 = request.args.get("doc_id_2")

--- a/flask_app.py
+++ b/flask_app.py
@@ -179,19 +179,46 @@ def doc_explore():
                            )
 
                 # loop through all queries
+                # (possibly want to limit number of docs to e.g. 100 or 500)
                 for i in range(IR_tools.doc_ids.index(doc_id), IR_tools.doc_ids.index(doc_id_2)+1):
                     # carry out query, get output in form of next batch of HTML rows
-                    docExploreInner_HTML += IR_tools.get_closest_docs(
-                        query_id=IR_tools.doc_ids[i],
-                        topic_weights=session['topic_weights'],
-                        topic_labels=session['topic_labels'],
+
+                    # what is actually necessary?
+                    # grab record (will always be available)
+                    #   - no, grab all at once
+                    #   - and maybe get scores at same time?
+                    #   - do NOT want 0.33 sec for EACH of grab, score, score
+                    # look through top few sw_w results until threshold exceeded
+                    #   - also filter at same time
+                    # construct result dict based on those doc_ids
+                    #   - topic not saved so calculate
+                    #   - also do text previews?
+                    # format result dict as HTML rows and return
+                    docExploreInner_HTML += IR_tools.get_closest_docs_with_db_only_batch_only(
+                        similarity_data,
+                        query_id=doc_id,
+                        sw_score_threshold=50,
                         priority_texts=session["priority_texts"],
-                        # topic_toggle_value=session["topic_toggle_value"]
-                        N_tf_idf=session["N_tf_idf_" + session["search_depth_default"]],
-                        N_sw_w=session["N_sw_w_" + session["search_depth_default"]],
-                        similarity_data=similarity_data,
-                        batch_mode=True,
                     )
+
+                # close off table
+                docExploreInner_HTML += """
+                  </tbody>
+                </table>
+                """
+
+
+                    # docExploreInner_HTML += IR_tools.get_closest_docs(
+                    #     query_id=IR_tools.doc_ids[i],
+                    #     topic_weights=session['topic_weights'],
+                    #     topic_labels=session['topic_labels'],
+                    #     priority_texts=session["priority_texts"],
+                    #     # topic_toggle_value=session["topic_toggle_value"]
+                    #     N_tf_idf=session["N_tf_idf_" + session["search_depth_default"]],
+                    #     N_sw_w=session["N_sw_w_" + session["search_depth_default"]],
+                    #     similarity_data=similarity_data,
+                    #     batch_mode=True,
+                    # )
 
             else:
                 # single-query mode

--- a/flask_app.py
+++ b/flask_app.py
@@ -128,9 +128,7 @@ def doc_explore():
             doc_id_2 = request.args.get("doc_id_2")
         else:
             local_doc_id_input_2 = request.form.get("local_doc_id_input_2")
-            if local_doc_id_input_2 is None:
-                local_doc_id_input_2 = ""
-            else:
+            if local_doc_id_input_2 not in ['', None]:
                 doc_id_2 = text_abbreviation_input + '_' + local_doc_id_input_2
 
         valid_doc_ids = IR_tools.doc_ids

--- a/flask_app.py
+++ b/flask_app.py
@@ -3,7 +3,7 @@ import html
 import re
 
 from datetime import datetime, date
-from flask import Flask, session, redirect, render_template, request, url_for, send_from_directory #, send_file
+from flask import Flask, session, redirect, render_template, request, url_for, send_from_directory
 from flask_pymongo import PyMongo
 
 import IR_tools
@@ -116,7 +116,6 @@ def doc_explore():
         local_doc_id_input = ""
         local_doc_id_input_2 = ""
         doc_id_2 = ""
-        threshold = 30
 
         if 'doc_id' in request.args:
             doc_id = request.args.get("doc_id")
@@ -202,7 +201,7 @@ def doc_explore():
                 # format result dict as HTML rows and return
 
                 best_results = IR_tools.batch_mode(similarity_data, doc_id, doc_id_2, sw_threshold)
-                docExploreInner_HTML = IR_tools.format_batch_results(best_results, doc_id, doc_id_2)
+                docExploreInner_HTML = IR_tools.format_batch_results(best_results, doc_id, doc_id_2, session["priority_texts"])
 
             else:
                 # single-query mode

--- a/templates/docExplore.html
+++ b/templates/docExplore.html
@@ -89,19 +89,30 @@
 			    	<div class="col-md-2">
 <!--			            <input id="doc_id" name="doc_id" type="text" class="form-control" placeholder="Enter doc id" size="30"/>-->
 						<select name="text_abbreviation_input" id="text_abbreviation_input" class="form-control">
-							<option value="{{ text_abbreviation }}" size="15" selected="selected">Select text</option>
+							<option value="" size="15" selected="selected">Select text</option>
 						</select>
 			        </div>
 					<div class="col-md-3">
 						<select name="local_doc_id_input" id="local_doc_id_input" class="form-control">
-							<option value="{{ local_doc_id }}" size="15" selected="selected">Select doc id</option>
+							<option value="" size="15" selected="selected">Select doc id</option>
 						</select>
 			        </div>
 			        <div class="col-md-1">
 			            <input id="doc_explore_submit_button" type="submit" class="btn btn-block btn-primary" value="Submit"/>
-
 			        </div>
 			    </div>
+				<div class="row">
+			    	<div class="col-md-2">
+			        </div>
+					<div class="col-md-3">
+						<select name="local_doc_id_input_2" id="local_doc_id_input_2" class="form-control">
+							<option value="" size="15" selected="selected">Select doc id</option>
+						</select>
+			        </div>
+					<div class="col-md-1">
+			        </div>
+			    </div>
+
 
 			</form>
 
@@ -127,16 +138,22 @@
 
 		var textAbbrevSel = document.getElementById("text_abbreviation_input");
 		var docIdSel = document.getElementById("local_doc_id_input");
+		var docIdSel_2 = document.getElementById("local_doc_id_input_2");
+
 		textAbbrevSel.length = 1;
 		for (var x in abbrv2docs) {
 			textAbbrevSel.options[textAbbrevSel.options.length] = new Option(x + ' ' + abbrev2title[x], x);
 		}
 		textAbbrevSel.onchange = function() {
 			docIdSel.length = 1;
+			docIdSel_2.length = 1;
 			for (var y of abbrv2docs[this.value]) {
 			  docIdSel.options[docIdSel.options.length] = new Option(y + ' ' + section_labels[this.value + '_' + y], y);
+			  <!-- eventually want this to contract based on docIdSel -->
+			  docIdSel_2.options[docIdSel_2.options.length] = new Option(y + ' ' + section_labels[this.value + '_' + y], y);
 			}
 		}
+
     </script>
 
 </html>

--- a/templates/docExplore.html
+++ b/templates/docExplore.html
@@ -125,6 +125,7 @@
 
 	    	$('#priority_col_table').DataTable( {"pageLength": 25} );
 	    	$('#secondary_col_table').DataTable( {"pageLength": 25} );
+	    	$('#batch_result_table').DataTable( {"pageLength": 25} );
 
 		} );
 	</script>

--- a/templates/docExplore.html
+++ b/templates/docExplore.html
@@ -107,7 +107,7 @@
 			        </div>
 					<div class="col-md-3">
 						<select name="local_doc_id_input_2" id="local_doc_id_input_2" class="form-control">
-							<option value="" size="15" selected="selected">Second doc id for batch mode</option>
+							<option value="" size="15" selected="selected">Subsequent doc id (batch mode)</option>
 						</select>
 			        </div>
 					<div class="col-md-1">
@@ -118,13 +118,12 @@
 					<div class="col-md-2">
 			        </div>
 					<div class="col-md-3" class="range">
-						<input type="range" class="form-range" name="sw_threshold" id="sw_threshold" min="30" max="300" step="10" value="30"/>
+						<input type="range" class="form-range" name="sw_threshold" id="sw_threshold" min="20" max="200" step="10" value="50"/>
 			        </div>
 					<div class="col-md-1">
-						<p id="sw_threshold_slider_label">sw score > 30</p>
+						<p id="sw_threshold_slider_label">sw score > 50</p>
 			        </div>
 				</div>
-
 
 			</form>
 

--- a/templates/docExplore.html
+++ b/templates/docExplore.html
@@ -94,24 +94,36 @@
 			        </div>
 					<div class="col-md-3">
 						<select name="local_doc_id_input" id="local_doc_id_input" class="form-control">
-							<option value="" size="15" selected="selected">Select doc id</option>
+							<option value="" size="15" selected="selected">Select query doc id</option>
 						</select>
 			        </div>
 			        <div class="col-md-1">
 			            <input id="doc_explore_submit_button" type="submit" class="btn btn-block btn-primary" value="Submit"/>
 			        </div>
 			    </div>
+				<br>
 				<div class="row">
 			    	<div class="col-md-2">
 			        </div>
 					<div class="col-md-3">
 						<select name="local_doc_id_input_2" id="local_doc_id_input_2" class="form-control">
-							<option value="" size="15" selected="selected">Select doc id</option>
+							<option value="" size="15" selected="selected">Second doc id for batch mode</option>
 						</select>
 			        </div>
 					<div class="col-md-1">
 			        </div>
 			    </div>
+				<br>
+				<div class="row" id="sw_threshold_slider_row" style='display: none;'>
+					<div class="col-md-2">
+			        </div>
+					<div class="col-md-3" class="range">
+						<input type="range" class="form-range" name="sw_threshold" id="sw_threshold" min="30" max="300" step="10" value="30"/>
+			        </div>
+					<div class="col-md-1">
+						<p id="sw_threshold_slider_label">sw score > 30</p>
+			        </div>
+				</div>
 
 
 			</form>
@@ -154,6 +166,16 @@
 			  docIdSel_2.options[docIdSel_2.options.length] = new Option(y + ' ' + section_labels[this.value + '_' + y], y);
 			}
 		}
+
+		docIdSel_2.onchange = function() {
+			var sw_threshold_slider_row = document.getElementById("sw_threshold_slider_row");
+	  		sw_threshold_slider_row.style.display = "block";
+	  	}
+
+	  	sw_threshold.onchange = function() {
+	  		var sw_threshold_slider_label = document.getElementById("sw_threshold_slider_label");
+	  		sw_threshold_slider_label.innerHTML = `sw score > ` + sw_threshold.value;
+	  	}
 
     </script>
 

--- a/templates/docExploreBatchInner.html
+++ b/templates/docExploreBatchInner.html
@@ -1,0 +1,3 @@
+$table_header_HTML
+$table_rows_HTML
+$table_footer_HTML


### PR DESCRIPTION
This MR takes advantage of the db improvements in MR #8 to bring the batch-mode functionality formerly present only in the repo's `batch_processing` Jupyter notebook into the Flask app itself.

Batch mode is activated simply by selecting two doc ids for docExplore rather than just one. After selecting the second doc id, a slider appears for controlling the `sw_w` score threshold.