### PR TITLE
fix: reduce defaults for search depth

### DIFF
--- a/IR_tools.py
+++ b/IR_tools.py
@@ -107,10 +107,10 @@ tf_idf_secs_per_comparison  = 0.000315 #  315 microseconds
 sw_w_secs_per_comparison    = 0.004513 # 4513 microseconds
 
 search_N_defaults = {
-    "N_tf_idf_shallow" : int( num_docs * 0.15),
-    "N_tf_idf_deep" : int( num_docs * 1.00),
-    "N_sw_w_shallow" : 200,
-    "N_sw_w_deep" : 1000
+    "N_tf_idf_shallow" : 500,
+    "N_tf_idf_deep" : 25,
+    "N_sw_w_shallow" : 2000,
+    "N_sw_w_deep" : 100
 }
 
 def new_full_vector(size, val):

--- a/IR_tools.py
+++ b/IR_tools.py
@@ -108,8 +108,8 @@ sw_w_secs_per_comparison    = 0.004513 # 4513 microseconds
 
 search_N_defaults = {
     "N_tf_idf_shallow" : 500,
-    "N_tf_idf_deep" : 25,
-    "N_sw_w_shallow" : 4000,
+    "N_tf_idf_deep" : 4000,
+    "N_sw_w_shallow" : 25,
     "N_sw_w_deep" : 200
 }
 

--- a/IR_tools.py
+++ b/IR_tools.py
@@ -109,8 +109,8 @@ sw_w_secs_per_comparison    = 0.004513 # 4513 microseconds
 search_N_defaults = {
     "N_tf_idf_shallow" : 500,
     "N_tf_idf_deep" : 25,
-    "N_sw_w_shallow" : 2000,
-    "N_sw_w_deep" : 100
+    "N_sw_w_shallow" : 4000,
+    "N_sw_w_deep" : 200
 }
 
 def new_full_vector(size, val):


### PR DESCRIPTION
The previous values of `search_N_defaults` were geared toward pre-db use. Now I don't want to encourage users to do as much extremely deep searching of this sort, at least not as the default. What had been the defaults for the shallow setting (15% TF-IDF, about 4000/200) is now the suggested deep setting (= the hard db write limits), and the new shallow setting is 500/25 (= the bare minimum). Most importantly, the old 100% TF-IDF deep is gone.