### PR TITLE
fix: check for a supply missing tf-idf scores

### DIFF
--- a/IR_tools.py
+++ b/IR_tools.py
@@ -1518,7 +1518,7 @@ def compare_doc_pair(   doc_id_1, doc_id_2,
 
     doc_1_topic_vector = np.array(thetas[doc_id_1])
     doc_2_topic_vector = np.array(thetas[doc_id_2])
-    topic_similiarity_score = 1-fastdist.cosine(doc_1_topic_vector, doc_2_topic_vector)
+    topic_similiarity_score = round(1-fastdist.cosine(doc_1_topic_vector, doc_2_topic_vector), 4)
 
     # print("do one-off topic comparison:", calc_dur(start1, datetime.now().time()))
     # print("overall:", calc_dur(start0, datetime.now().time()))
@@ -1530,7 +1530,7 @@ def compare_doc_pair(   doc_id_1, doc_id_2,
         # start1 = datetime.now().time()
 
         doc_1_TF_IDF_vector, doc_2_TF_IDF_vector = get_tiny_TF_IDF_vectors(doc_id_1, doc_id_2)
-        TF_IDF_comparison_score = 1 - fastdist.cosine(doc_1_TF_IDF_vector, doc_2_TF_IDF_vector)
+        TF_IDF_comparison_score = round(1 - fastdist.cosine(doc_1_TF_IDF_vector, doc_2_TF_IDF_vector), 4)
 
         # print("do one-off tf-idf comparison:", calc_dur(start1, datetime.now().time()))
         # print("overall:", calc_dur(start0, datetime.now().time()))


### PR DESCRIPTION
Something with a low tf-idf score can result in a high enough sw score for the the latter to get saved while the former gets truncated. Later, in post-processing, when working backward from sw, nothing checks to make sure that there aren't these gaps in tf-idf values. So, add an error check that fills with a one-off tf-idf score at this post-processing step. This is after the write to the db, so nothing changes about what is going into and out of the db. 