### PR TITLE
fix: use safer SAVE_LIMITs

### DIFF
--- a/IR_tools.py
+++ b/IR_tools.py
@@ -787,8 +787,8 @@ def truncate_dict(dictionary: Dict, n: int) -> Dict:
         for (k, v) in list(dictionary.items())[:n]
     }
 
-N_TDIDF_SAVE_LIMIT = 4000
-N_SW_SAVE_LIMIT = 200
+N_TDIDF_SAVE_LIMIT = 2500
+N_SW_SAVE_LIMIT = 500
 def get_closest_docs_with_db(
         similarity_data: PymongoCollection,
         query_id,


### PR DESCRIPTION
After preprocessing the entire corpus with 
`get_closest_docs_with_db(..., N_tfidf=2000, N_sw=100)`
the overall db size on Mongo DB has climbed to ~1.7 GB, which is dangerously close to the M2 2GB limit that I don't want to exceed for money reasons. However, in the process of adding the checks for missing tf-idf scores (#18, #19), it's become clearer how much more valuable sw scores are, since each mode (single/batch) can so quickly supply missing tf-idf scores. So, reduce `N_TDIDF_SAVE_LIMIT` from 4000 to 2500 but actually increase `N_SW_SAVE_LIMIT` from 100 to 500.