### PR TITLE
fix: allow batch input with just text abbreviation

### DIFF
--- a/IR_tools.py
+++ b/IR_tools.py
@@ -461,7 +461,13 @@ def get_TF_IDF_vector(doc_id):
 # phasing out...
 # import pdb; pdb.set_trace()
 # conditionally_do_batch_tf_idf_comparisons(*doc_ids[:5], N=1000)
-NBhu_doc_ids = [ di for di in doc_ids if parse_complex_doc_id(di)[0] == 'NBhū' ]
+text_doc_ids = {}
+text_abbrevs = list(text_abbrev2fn.keys())
+for text_abbrev in text_abbrevs:
+    text_doc_ids[text_abbrev] = [
+        doc_id for doc_id in doc_ids if parse_complex_doc_id(doc_id)[0] == text_abbrev
+    ]
+# NBhu_doc_ids = [ di for di in doc_ids if parse_complex_doc_id(di)[0] == 'NBhū' ]
 # print(len(NBhu_doc_ids))
 # conditionally_do_batch_tf_idf_comparisons(*NBhu_doc_ids, N=1000)
 

--- a/flask_app.py
+++ b/flask_app.py
@@ -118,7 +118,8 @@ def doc_explore():
         else:
             text_abbreviation_input = request.form.get("text_abbreviation_input")
             local_doc_id_input = request.form.get("local_doc_id_input")
-            doc_id = text_abbreviation_input + '_' + local_doc_id_input
+            if local_doc_id_input not in ['', None]:
+                doc_id = text_abbreviation_input + '_' + local_doc_id_input
 
         if 'doc_id_2' in request.args:
             doc_id_2 = request.args.get("doc_id_2")
@@ -129,8 +130,15 @@ def doc_explore():
 
         if 'sw_threshold' in request.args:
             sw_threshold = request.args.get("sw_threshold")
-        else:
+        elif 'sw_threshold' in request.form:
             sw_threshold = request.form.get("sw_threshold")
+        else:
+            sw_threshold = 50
+
+        if local_doc_id_input in ['', None] and local_doc_id_input_2 in ['', None]:
+            text_id_list = IR_tools.text_doc_ids[text_abbreviation_input]
+            doc_id = text_id_list[0]
+            doc_id_2 = text_id_list[-1]
 
         valid_doc_ids = IR_tools.doc_ids
         if (


### PR DESCRIPTION
Giving just a text abbreviation should be a valid input to batch mode, namely meaning "whole work with default score threshold". Handle args so as to make this possible. This is basically a secret feature.