### PR TITLE
fix: overlooked one check on doc_id 

### DIFF
--- a/flask_app.py
+++ b/flask_app.py
@@ -109,9 +109,10 @@ def doc_explore():
         # NB: not yet supported is sending 'text_abbrv' and 'local_doc_id' via GET
 
         text_abbreviation_input = ""
+        doc_id = ""
+        doc_id_2 = ""
         local_doc_id_input = ""
         local_doc_id_input_2 = ""
-        doc_id_2 = ""
 
         if 'doc_id' in request.args:
             doc_id = request.args.get("doc_id")
@@ -135,7 +136,7 @@ def doc_explore():
         else:
             sw_threshold = 50
 
-        if local_doc_id_input in ['', None] and local_doc_id_input_2 in ['', None]:
+        if doc_id in ['', None] and local_doc_id_input in ['', None] and local_doc_id_input_2 in ['', None]:
             text_id_list = IR_tools.text_doc_ids[text_abbreviation_input]
             doc_id = text_id_list[0]
             doc_id_2 = text_id_list[-1]


### PR DESCRIPTION
In previous PR #21 , which allowed for `docExplore` queries consisting of just a text abbreviation (= a batch search with default parameters), I forgot to cover the case where `text_abbreviation_input` is empty and `doc_id` is not (= any one of many GET requests in intra-system links which sends the entire doc id as one unit). This led to an `IndexError` on `IR_tools.text_doc_ids[text_abbreviation_input]`. Therefore simply skip this `if` block if `doc_id` is not empty.