### PR TITLE
feat(docCompare, docExplore): improve doc nav buttons (v1.0.15)

### DIFF
--- a/IR_tools.py
+++ b/IR_tools.py
@@ -1417,15 +1417,27 @@ def compare_doc_pair(   doc_id_1, doc_id_2,
 
     results_HTML = HTML_templates['docCompareInner'].substitute(
                     doc_id_1=doc_id_1, doc_id_2=doc_id_2,
+                    doc_id_1_work_name=(doc_id_1_work_name := parse_complex_doc_id(doc_id_1)[0]),
+                    doc_id_2_work_name=(doc_id_2_work_name := parse_complex_doc_id(doc_id_2)[0]),
+                    doc_id_1_local=(doc_id_1_local := get_full_local_doc_id(doc_id_1)),
+                    doc_id_2_local=(doc_id_2_local := get_full_local_doc_id(doc_id_2)),
 
-                    doc_id_1_work_name=parse_complex_doc_id(doc_id_1)[0],
-                    doc_id_2_work_name=parse_complex_doc_id(doc_id_2)[0],
+                    text_1_doc_pos=abbrv2docs[doc_id_1_work_name].index(doc_id_1_local)+1,
+                    text_2_doc_pos=abbrv2docs[doc_id_2_work_name].index(doc_id_2_local)+1,
+                    text_1_doc_count=len(abbrv2docs[doc_id_1_work_name]),
+                    text_2_doc_count=len(abbrv2docs[doc_id_2_work_name]),
 
                     doc_section_1=section_labels[doc_id_1],
                     doc_section_2=section_labels[doc_id_2],
 
-                    prev_doc_id_1=doc_links[doc_id_1]['prev'], prev_doc_id_2=doc_links[doc_id_2]['prev'],
-                    next_doc_id_1=doc_links[doc_id_1]['next'], next_doc_id_2=doc_links[doc_id_2]['next'],
+                    first_doc_id_1=get_full_local_doc_id(doc_links[doc_id_1]['first']),
+                    first_doc_id_2=get_full_local_doc_id(doc_links[doc_id_2]['first']),
+                    prev_doc_id_1=get_full_local_doc_id(doc_links[doc_id_1]['prev']),
+                    prev_doc_id_2=get_full_local_doc_id(doc_links[doc_id_2]['prev']),
+                    next_doc_id_1=get_full_local_doc_id(doc_links[doc_id_1]['next']),
+                    next_doc_id_2=get_full_local_doc_id(doc_links[doc_id_2]['next']),
+                    last_doc_id_1=get_full_local_doc_id(doc_links[doc_id_1]['last']),
+                    last_doc_id_2=get_full_local_doc_id(doc_links[doc_id_2]['last']),
 
                     prev_sim_doc_id_for_2=prev_sim_doc_id_for_2, # left
                     next_sim_doc_id_for_2=next_sim_doc_id_for_2,
@@ -1438,6 +1450,8 @@ def compare_doc_pair(   doc_id_1, doc_id_2,
                     sim_rank_of_prev_for_1=sim_rank_of_prev_for_1,
                     sim_rank_of_2_for_1=sim_rank_of_2_for_1,
                     sim_rank_of_next_for_1=sim_rank_of_next_for_1,
+
+                    N_sw_w=N_sw_w,
 
                     doc_segmented_highlighted_fulltext_1=highlighted_HTML_1,
                     doc_segmented_highlighted_fulltext_2=highlighted_HTML_2,

--- a/IR_tools.py
+++ b/IR_tools.py
@@ -737,71 +737,6 @@ def get_closest_docs_with_db(
         upsert=True
     )
 
-    # end = datetime.now().time()
-    # overall_time = calc_dur(start, end)
-    # print("just getting stuff from db:", overall_time)
-    # start = datetime.now().time()
-    #
-    # # perform filtering and result supplementation based on priority doc list
-    # topic_similar_docs_filtered = {
-    #     k: v for k, v in topic_similar_docs.items() if parse_complex_doc_id(k)[0] in priority_texts
-    # }
-    #
-    # end = datetime.now().time()
-    # overall_time = calc_dur(start, end)
-    # print(f"filtering topic results (len(topic_similar_docs)=={len(topic_similar_docs)}):", overall_time)
-    # start = datetime.now().time()
-    #
-    # tf_idf_similar_docs_filtered = {
-    #     k:v for k,v in tf_idf_similar_docs.items() if parse_complex_doc_id(k)[0] in priority_texts
-    # }
-    #
-    # end = datetime.now().time()
-    # overall_time = calc_dur(start, end)
-    # print(f"filtering tf-idf results (len(tf_idf_similar_docs)=={len(tf_idf_similar_docs)}):", overall_time)
-    # start = datetime.now().time()
-    #
-    # sw_w_similar_docs_filtered = {
-    #     k: v for k, v in sw_w_similar_docs.items() if parse_complex_doc_id(k)[0] in priority_texts
-    # }
-    #
-    # end = datetime.now().time()
-    # overall_time = calc_dur(start, end)
-    # print(f"filtering sw_w results (len(sw_w_similar_docs)=={len(sw_w_similar_docs)}):", overall_time)
-    # start = datetime.now().time()
-    #
-    # additional_tfidf = rank_candidates_by_tiny_TF_IDF_similarity(
-    #     doc_id,
-    #     list(topic_similar_docs_filtered.keys())[len(tf_idf_similar_docs_filtered):N_tfidf]
-    # )
-    #
-    # end = datetime.now().time()
-    # overall_time = calc_dur(start, end)
-    # print(f"additional_tfidf ({N_tfidf-len(tf_idf_similar_docs_filtered)}):", overall_time)
-    #
-    # tf_idf_similar_docs_filtered = dict(tf_idf_similar_docs_filtered, **additional_tfidf)
-    #
-    # start = datetime.now().time()
-    #
-    # additional_sw = rank_candidates_by_sw_w_alignment_score(
-    #     doc_id,
-    #     list(tf_idf_similar_docs_filtered.keys())[len(sw_w_similar_docs_filtered):N_sw]
-    # )
-    #
-    # end = datetime.now().time()
-    # overall_time = calc_dur(start, end)
-    # print(f"additional_sw ({N_sw-len(sw_w_similar_docs_filtered)}):", overall_time)
-    #
-    # sw_w_similar_docs_filtered = dict(sw_w_similar_docs_filtered, **additional_sw)
-    #
-    # similar_docs = {
-    #     'topic': topic_similar_docs_filtered,
-    #     'tf_idf': tf_idf_similar_docs_filtered,
-    #     'sw_w': sw_w_similar_docs_filtered
-    # }
-    #
-    # breakpoint()
-
     return similar_docs
 
 
@@ -837,7 +772,7 @@ def get_closest_docs(   query_id,
     non_priority_texts = [text for text in list(text_abbrev2fn.keys()) if text not in priority_texts]
 
     start0 = datetime.now().time()
-    # get num of docs in priority_texts to use for comupatation time calculations
+    # get num of docs in priority_texts to use for computation time calculations
     num_priority_docs = sum([ num_docs_by_text[text_name] for text_name in priority_texts ])
 
     # start1 = datetime.now().time()

--- a/IR_tools.py
+++ b/IR_tools.py
@@ -782,8 +782,23 @@ def get_closest_docs(   query_id,
     # handle blank
     if doc_fulltext[query_id] == '':
         results_HTML = HTML_templates['docExploreInner'].substitute(
-            query_id = query_id, query_section = section_labels[query_id], prev_doc_id = doc_links[query_id]['prev'], next_doc_id = doc_links[query_id]['next'],
-            query_original_fulltext = doc_original_fulltext[query_id], query_segmented_fulltext = '', top_topics_summary='', priority_results_list_content = '', secondary_results_list_content = '', priority_texts=str(priority_texts), non_priority_texts=str(non_priority_texts)
+            query_id = query_id,
+            query_work_name=(query_work_name := parse_complex_doc_id(query_id)[0]),
+            query_id_local=(query_id_local := get_full_local_doc_id(query_id)),
+            first_doc_id=get_full_local_doc_id(doc_links[query_id]['first']),
+            prev_doc_id=get_full_local_doc_id(doc_links[query_id]['prev']),
+            next_doc_id=get_full_local_doc_id(doc_links[query_id]['next']),
+            last_doc_id=get_full_local_doc_id(doc_links[query_id]['last']),
+            query_text_pos=abbrv2docs[query_work_name].index(query_id_local) + 1,
+            query_text_doc_count=len(abbrv2docs[query_work_name]),
+            query_section=section_labels[query_id],
+            query_original_fulltext = doc_original_fulltext[query_id],
+            query_segmented_fulltext = '',
+            top_topics_summary='',
+            priority_results_list_content = '',
+            secondary_results_list_content = '',
+            priority_texts=str(priority_texts),
+            non_priority_texts=str(non_priority_texts),
             )
         return results_HTML
 
@@ -981,9 +996,15 @@ def get_closest_docs(   query_id,
         secondary_col_HTML = "<p>(none)</p>" # just neutralize for now until i can make faster
         results_HTML = HTML_templates['docExploreInner'].substitute(
                             query_id = query_id,
+                            query_work_name=(query_work_name := parse_complex_doc_id(query_id)[0]),
+                            query_id_local=(query_id_local := get_full_local_doc_id(query_id)),
+                            first_doc_id=get_full_local_doc_id(doc_links[query_id]['first']),
+                            prev_doc_id=get_full_local_doc_id(doc_links[query_id]['prev']),
+                            next_doc_id=get_full_local_doc_id(doc_links[query_id]['next']),
+                            last_doc_id=get_full_local_doc_id(doc_links[query_id]['last']),
+                            query_text_pos=abbrv2docs[query_work_name].index(query_id_local) + 1,
+                            query_text_doc_count=len(abbrv2docs[query_work_name]),
                             query_section = section_labels[query_id],
-                            prev_doc_id = doc_links[query_id]['prev'],
-                            next_doc_id = doc_links[query_id]['next'],
                             query_original_fulltext = doc_original_fulltext[query_id],
                             query_segmented_fulltext = doc_fulltext[query_id],
                             top_topics_summary=format_top_topic_summary(

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-__app_version__ = "1.0.14"
+__app_version__ = "1.0.15"

--- a/templates/docCompare.html
+++ b/templates/docCompare.html
@@ -143,16 +143,70 @@
         	function conditionally_display_similar_doc_link_buttons() {
                 sim_btn_left = "{{ activate_similar_link_buttons_left }}";
                 if ( sim_btn_left.length > 0 ) {
-                    document.getElementById("similar_doc_link_btns_left").style.visibility = "visible";
+                    document.getElementById("sim-nav-left").style.visibility = "visible";
                 }
                 sim_btn_right = "{{ activate_similar_link_buttons_right }}";
                 if ( sim_btn_right.length > 0 ) {
-                    document.getElementById("similar_doc_link_btns_right").style.visibility = "visible";
+                    document.getElementById("sim-nav-right").style.visibility = "visible";
                 }
             }
 
          	window.onload = function() {
                 conditionally_display_similar_doc_link_buttons();
+
+              // ─── DOCUMENT NAVIGATION: first/prev/next/last for left & right ─────────────────
+			  ['left','right'].forEach(side => {
+				const container = document.getElementById(`doc-compare-${side}`);
+				if (!container) return;
+
+				const current = container.dataset.current;
+				const first   = container.dataset.first;
+				const last    = container.dataset.last;
+
+				['first','prev','next','last'].forEach(type => {
+				  const btn = document.getElementById(`btn-${type}-${side}`);
+				  if (!btn) return;
+
+				  // hide first & prev at the start
+				  if ((type === 'first' || type === 'prev') && current === first) {
+					btn.style.visibility = 'hidden';
+				  }
+				  // hide next & last at the end
+				  if ((type === 'next' || type === 'last') && current === last) {
+					btn.style.visibility = 'hidden';
+				  }
+				});
+			  });
+
+			  // ─── SIMILARITY NAVIGATION: for left & right ─────────────────────────────────────
+			  ['left','right'].forEach(side => {
+				const simNav = document.getElementById(`sim-nav-${side}`);
+				if (!simNav) return;
+
+				const rank  = parseInt(simNav.dataset.rank,  10) || 0;
+				const total = parseInt(simNav.dataset.total, 10) || 0;
+
+				// always show the row
+				simNav.style.display = '';
+
+				// hide entire row if invalid rank
+				if (rank < 1 || rank > total) {
+				  simNav.style.display = 'none';
+				  return;
+				}
+
+				// hide the “more similar” button at rank 1
+				const btnPrev = document.getElementById(`sim-prev-btn-${side}`);
+				if (rank === 1 && btnPrev) {
+				  btnPrev.style.visibility = 'hidden';
+				}
+
+				// hide the “less similar” button at rank=total
+				const btnNext = document.getElementById(`sim-next-btn-${side}`);
+				if (rank === total && btnNext) {
+				  btnNext.style.visibility = 'hidden';
+				}
+			  });
             }
 
 			var abbrv2docs = {{ abbrv2docs|tojson|safe }};
@@ -184,8 +238,6 @@
 				  docIdSel_2.options[docIdSel_2.options.length] = new Option(y + ' ' + section_labels[this.value + '_' + y], y);
 				}
 			}
-
-    </script>
         </script>
 
     </body>

--- a/templates/docCompare.html
+++ b/templates/docCompare.html
@@ -169,11 +169,13 @@
 
 				  // hide first & prev at the start
 				  if ((type === 'first' || type === 'prev') && current === first) {
-					btn.style.visibility = 'hidden';
+					btn.disabled = true;
+					btn.classList.add('disabled');
 				  }
 				  // hide next & last at the end
 				  if ((type === 'next' || type === 'last') && current === last) {
-					btn.style.visibility = 'hidden';
+					btn.disabled = true;
+					btn.classList.add('disabled');
 				  }
 				});
 			  });
@@ -198,13 +200,15 @@
 				// hide the “more similar” button at rank 1
 				const btnPrev = document.getElementById(`sim-prev-btn-${side}`);
 				if (rank === 1 && btnPrev) {
-				  btnPrev.style.visibility = 'hidden';
+				  btnPrev.disabled = true;
+				  btnPrev.classList.add('disabled');
 				}
 
 				// hide the “less similar” button at rank=total
 				const btnNext = document.getElementById(`sim-next-btn-${side}`);
 				if (rank === total && btnNext) {
-				  btnNext.style.visibility = 'hidden';
+				  btnNext.disabled = true;
+				  Next.classList.add('disabled');
 				}
 			  });
             }

--- a/templates/docCompareInner.html
+++ b/templates/docCompareInner.html
@@ -1,108 +1,241 @@
+<style>
+  /* remove ugly blue outline/shadow on small btns when clicked */
+  .btn-no-outline:focus,
+  .btn-no-outline:active {
+    outline: none !important;
+    box-shadow: none !important;
+  }
+</style>
+
 <div class="row">
 
-	<div class="col-md-6">
+	<div class="col-md-6" id="doc-compare-left"
+		data-current="$doc_id_1_local"
+		data-first="$first_doc_id_1"
+		data-last="$last_doc_id_1">
 
-		<h1>
-			<span title="$doc_section_1">$doc_id_1  </span>
-			<small><small><sup>(<a href="docExplore?doc_id=$doc_id_1">docExpl</a>) (<a href="textView?doc_id=$doc_id_1">txtVw</a>)</sup></small></small>
-		</h1>
+	  <h1>
+		<span title="$doc_section_1">$doc_id_1</span>
+		<small><sup>
+		  (<a href="docExplore?doc_id=$doc_id_1">docExpl</a>)
+		  (<a href="textView?doc_id=$doc_id_1">txtVw</a>)
+		</sup></small>
+	  </h1>
 
-		<div class="row">
-
-			<div class="col-md-4">
-				<form method="get" action="docCompare">
-					<input type="hidden" name="doc_id_1" value="$prev_doc_id_1" />
-					<input type="hidden" name="doc_id_2" value="$doc_id_2" />
-					<input type="submit" class="btn btn-block btn-primary" value="<< $prev_doc_id_1" />
-				</form>
-			</div>
-
-			<div class="col-md-4">
-				<form method="get" action="docCompare">
-					<input type="hidden" name="doc_id_1" value="$next_doc_id_1" />
-					<input type="hidden" name="doc_id_2" value="$doc_id_2" />
-					<input type="submit" class="btn btn-block btn-primary" value="$next_doc_id_1 >>" />
-				</form>
-			</div>
-
-			<p>within $doc_id_1_work_name</p>
-
+	  <!-- ─── 1) DOCUMENT NAVIGATION: FIRST  PREV  NEXT  LAST ─────────────────── -->
+	  <div class="row mb-2">
+		<div class="col-md-2">
+		  <form method="get" action="docCompare">
+			<input type="hidden" name="doc_id_1" value="${doc_id_1_work_name}_${first_doc_id_1}"/>
+			<input type="hidden" name="doc_id_2" value="$doc_id_2"/>
+			<button id="btn-first-left"
+					type="submit"
+					class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
+					data-doc-id="$first_doc_id_1"
+					title="Go to first passage ($first_doc_id_1)">
+			  «
+			</button>
+		  </form>
 		</div>
 
-		<div class="row" id="similar_doc_link_btns_left" style="visibility: hidden">
-
-			<div class="col-md-4">
-				<form method="get" action="docCompare">
-					<input type="hidden" name="doc_id_1" value="$prev_sim_doc_id_for_2" />
-					<input type="hidden" name="doc_id_2" value="$doc_id_2" />
-					<input type="submit" class="btn btn-block btn-primary" value="(#$sim_rank_of_prev_for_2) $prev_sim_doc_id_for_2" />
-				</form>
-			</div>
-
-			<div class="col-md-4">
-				<form method="get" action="docCompare">
-					<input type="hidden" name="doc_id_1" value="$next_sim_doc_id_for_2" />
-					<input type="hidden" name="doc_id_2" value="$doc_id_2" />
-					<input type="submit" class="btn btn-block btn-primary" value="(#$sim_rank_of_next_for_2) $next_sim_doc_id_for_2" />
-				</form>
-			</div>
-
-			<p>similar doc #$sim_rank_of_1_for_2 for <br>$doc_id_2</p>
-
+		<div class="col-md-2">
+		  <form method="get" action="docCompare">
+			<input type="hidden" name="doc_id_1" value="${doc_id_1_work_name}_${prev_doc_id_1}"/>
+			<input type="hidden" name="doc_id_2" value="$doc_id_2"/>
+			<button id="btn-prev-left"
+					type="submit"
+					class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
+					data-doc-id="$first_doc_id_1"
+					title="Go to previous passage ($prev_doc_id_1)">
+			  ←
+			</button>
+		  </form>
 		</div>
+
+		<div class="col-md-4 text-center">
+		  <small>within <em>$doc_id_1_work_name</em> $text_1_doc_pos of $text_1_doc_count</small>
+		</div>
+
+		<div class="col-md-2">
+		  <form method="get" action="docCompare">
+			<input type="hidden" name="doc_id_1" value="${doc_id_1_work_name}_${next_doc_id_1}"/>
+			<input type="hidden" name="doc_id_2" value="$doc_id_2"/>
+			<button id="btn-next-left"
+					type="submit"
+					class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
+					data-doc-id="$first_doc_id_1"
+					title="Go to next passage ($next_doc_id_1)">
+			  →
+			</button>
+		  </form>
+		</div>
+
+		<div class="col-md-2">
+		  <form method="get" action="docCompare">
+			<input type="hidden" name="doc_id_1" value="${doc_id_1_work_name}_${last_doc_id_1}"/>
+			<input type="hidden" name="doc_id_2" value="$doc_id_2"/>
+			<button id="btn-last-left"
+					type="submit"
+					class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
+					data-doc-id="$first_doc_id_1"
+					title="Go to last passage ($last_doc_id_1)">
+			  »
+			</button>
+		  </form>
+		</div>
+	  </div>
+
+	  <!-- ─── 2) SIMILARITY NAVIGATION ───────────────────────────────────────────── -->
+	  <div class="row mb-2" id="sim-nav-left" style="visibility: hidden"
+		   data-rank="$sim_rank_of_1_for_2"
+		   data-total="$N_sw_w">
+		<div class="col-md-4">
+		  <form method="get" action="docCompare">
+			<input type="hidden" name="doc_id_1" value="$prev_sim_doc_id_for_2"/>
+			<input type="hidden" name="doc_id_2" value="$doc_id_2"/>
+			<button id="sim-prev-btn-left"
+					type="submit"
+					class="btn btn-block btn-primary btn-no-outline"
+					title="Go to more similar (#$sim_rank_of_prev_for_2 of $N_sw_w)">
+			  ←
+			</button>
+		  </form>
+		</div>
+
+		<div class="col-md-4 text-center">
+		  <small id="sim-status-left">
+			most similar #$sim_rank_of_1_for_2 of $N_sw_w for <em>$doc_id_2</em>
+		  </small>
+		</div>
+
+		<div class="col-md-4 text-right">
+		  <form method="get" action="docCompare">
+			<input type="hidden" name="doc_id_1" value="$next_sim_doc_id_for_2"/>
+			<input type="hidden" name="doc_id_2" value="$doc_id_2"/>
+			<button id="sim-next-btn-left"
+					type="submit"
+					class="btn btn-block btn-primary btn-no-outline"
+					title="Go to less similar (#$sim_rank_of_next_for_2 of $N_sw_w)">
+			  →
+			</button>
+		  </form>
+		</div>
+	  </div>
 
 	</div>
 
-	<div class="col-md-6">
+	<div class="col-md-6" id="doc-compare-right"
+		data-current="$doc_id_2_local"
+		data-first="$first_doc_id_2"
+		data-last="$last_doc_id_2">
 
-		<h1>
-			<span title="$doc_section_2">$doc_id_2  </span>
-			<small><small><sup>(<a href="docExplore?doc_id=$doc_id_2">docExpl</a>) (<a href="textView?doc_id=$doc_id_2">txtVw</a>)</sup></small></small>
-		</h1>
+	  <h1>
+		<span title="$doc_section_2">$doc_id_2</span>
+		<small><sup>
+		  (<a href="docExplore?doc_id=$doc_id_2">docExpl</a>)
+		  (<a href="textView?doc_id=$doc_id_2">txtVw</a>)
+		</sup></small>
+	  </h1>
 
-		<div class="row">
-
-			<div class="col-md-4">
-				<form method="get" action="docCompare">
-					<input type="hidden" name="doc_id_1" value="$doc_id_1" />
-					<input type="hidden" name="doc_id_2" value="$prev_doc_id_2" />
-					<input type="submit" class="btn btn-block btn-primary" value="<< $prev_doc_id_2" />
-				</form>
-			</div>
-
-			<div class="col-md-4">
-				<form method="get" action="docCompare">
-					<input type="hidden" name="doc_id_1" value="$doc_id_1" />
-					<input type="hidden" name="doc_id_2" value="$next_doc_id_2" />
-					<input type="submit" class="btn btn-block btn-primary" value="$next_doc_id_2 >>" />
-				</form>
-			</div>
-
-			<p>within $doc_id_2_work_name</p>
-
+	  <!-- ─── 1) DOCUMENT NAVIGATION: FIRST  PREV  NEXT  LAST ─────────────────── -->
+	  <div class="row mb-2">
+		<div class="col-md-2">
+		  <form method="get" action="docCompare">
+			<input type="hidden" name="doc_id_2" value="${doc_id_2_work_name}_${first_doc_id_2}"/>
+			<input type="hidden" name="doc_id_1" value="$doc_id_1"/>
+			<button id="btn-first-right"
+					type="submit"
+					class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
+					data-doc-id="$first_doc_id_2"
+					title="Go to first passage ($first_doc_id_2)">
+			  «
+			</button>
+		  </form>
 		</div>
 
-		<div class="row" id="similar_doc_link_btns_right" style="visibility: hidden">
-
-			<div class="col-md-4">
-				<form method="get" action="docCompare">
-					<input type="hidden" name="doc_id_1" value="$doc_id_1" />
-					<input type="hidden" name="doc_id_2" value="$prev_sim_doc_id_for_1" />
-					<input type="submit" class="btn btn-block btn-primary" value="(#$sim_rank_of_prev_for_1) $prev_sim_doc_id_for_1" />
-				</form>
-			</div>
-
-			<div class="col-md-4">
-				<form method="get" action="docCompare">
-					<input type="hidden" name="doc_id_1" value="$doc_id_1" />
-					<input type="hidden" name="doc_id_2" value="$next_sim_doc_id_for_1" />
-					<input type="submit" class="btn btn-block btn-primary" value="(#$sim_rank_of_next_for_1) $next_sim_doc_id_for_1" />
-				</form>
-			</div>
-
-			<p>similar doc #$sim_rank_of_2_for_1 for <br>$doc_id_1</p>
-
+		<div class="col-md-2">
+		  <form method="get" action="docCompare">
+			<input type="hidden" name="doc_id_2" value="${doc_id_2_work_name}_${prev_doc_id_2}"/>
+			<input type="hidden" name="doc_id_1" value="$doc_id_1"/>
+			<button id="btn-prev-right"
+					type="submit"
+					class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
+					data-doc-id="$first_doc_id_2"
+					title="Go to previous passage ($prev_doc_id_2)">
+			  ←
+			</button>
+		  </form>
 		</div>
+
+		<div class="col-md-4 text-center">
+		  <small>within <em>$doc_id_2_work_name</em> $text_2_doc_pos of $text_2_doc_count</small>
+		</div>
+
+		<div class="col-md-2">
+		  <form method="get" action="docCompare">
+			<input type="hidden" name="doc_id_2" value="${doc_id_2_work_name}_${next_doc_id_2}"/>
+			<input type="hidden" name="doc_id_1" value="$doc_id_1"/>
+			<button id="btn-next-right"
+					type="submit"
+					class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
+					data-doc-id="$first_doc_id_2"
+					title="Go to next passage ($next_doc_id_2)">
+			  →
+			</button>
+		  </form>
+		</div>
+
+		<div class="col-md-2">
+		  <form method="get" action="docCompare">
+			<input type="hidden" name="doc_id_2" value="${doc_id_2_work_name}_${last_doc_id_2}"/>
+			<input type="hidden" name="doc_id_1" value="$doc_id_1"/>
+			<button id="btn-last-right"
+					type="submit"
+					class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
+					data-doc-id="$first_doc_id_2"
+					title="Go to last passage ($last_doc_id_2)">
+			  »
+			</button>
+		  </form>
+		</div>
+	  </div>
+
+	  <!-- ─── 2) SIMILARITY NAVIGATION ───────────────────────────────────────────── -->
+	  <div class="row mb-2" id="sim-nav-right" style="visibility: hidden"
+		   data-rank="$sim_rank_of_2_for_1"
+		   data-total="$N_sw_w">
+		<div class="col-md-4">
+		  <form method="get" action="docCompare">
+			<input type="hidden" name="doc_id_2" value="$prev_sim_doc_id_for_1"/>
+			<input type="hidden" name="doc_id_1" value="$doc_id_1"/>
+			<button id="sim-prev-btn-right"
+					type="submit"
+					class="btn btn-block btn-primary btn-no-outline"
+					title="Go to more similar (#$sim_rank_of_prev_for_1 of $N_sw_w)">
+			  ←
+			</button>
+		  </form>
+		</div>
+
+		<div class="col-md-4 text-center">
+		  <small id="sim-status-right">
+			most similar #$sim_rank_of_2_for_1 of $N_sw_w for <em>$doc_id_1</em>
+		  </small>
+		</div>
+
+		<div class="col-md-4 text-right">
+		  <form method="get" action="docCompare">
+			<input type="hidden" name="doc_id_2" value="$next_sim_doc_id_for_1"/>
+			<input type="hidden" name="doc_id_1" value="$doc_id_1"/>
+			<button id="sim-next-btn-right"
+					type="submit"
+					class="btn btn-block btn-primary btn-no-outline"
+					title="Go to less similar (#$sim_rank_of_next_for_1 of $N_sw_w)">
+			  →
+			</button>
+		  </form>
+		</div>
+	  </div>
 
 	</div>
 
@@ -126,14 +259,14 @@
 
 	<div class="col-md-6">
 		<h2>Topic Analysis</h2>
-		<img id="plot" src="/assets/doc_plot_pngs/$doc_id_1.png" alt="oops" width="550" height="385">
+		<img id="plot1" src="/assets/doc_plot_pngs/$doc_id_1.png" alt="oops" width="550" height="385">
 		$top_topics_summary_1
 	</div>
 
 
 	<div class="col-md-6">
 		<h2>Topic Analysis</h2>
-		<img id="plot" src="/assets/doc_plot_pngs/$doc_id_2.png" alt="oops" width="550" height="385">
+		<img id="plot2" src="/assets/doc_plot_pngs/$doc_id_2.png" alt="oops" width="550" height="385">
 		$top_topics_summary_2
 	</div>
 
@@ -145,23 +278,28 @@
 
 	<span style="text-align: center;">
 		<h2>Doc Similarity Scores</h2>
-		<table class='display' style="margin-left: auto; margin-right: auto;">
+		<table class='display' style="margin-left: auto; margin-right: auto; text-align: center;">
 			<tr>
-				<td><h2><small>Topic Similarity<span title="K-dim vector cosine similarity">*</span></small></h2></td>
+				<th style="text-align: center;"><h2><small><b>Comparison</b></small></h2></th>
+				<th style="text-align: center;"><h2><small><b>Score</b></small></h2></th>
+				<th style="text-align: center;"><h2><small><b>Score Type</b></small></h2></th>
+			</tr>
+			<tr>
+				<td><h2><small>Topic (LDA)</small></h2></td>
 				<td><h2><small>$topic_similiarity_score</small></h2></td>
+				<td><h2><small>Vector cosine similarity (0.0–1.0)</small></h2></td>
 			</tr>
 			<tr>
-				<td><h2><small>TF.IDF Similarity<span title="reduced-vocab-dim vector cosine similarity">*</span></small></h2></td>
+				<td><h2><small>Word (TF-IDF)</small></h2></td>
 				<td><h2><small>$TF_IDF_comparison_score</small></h2></td>
+				<td><h2><small>Vector cosine similarity (0.0–1.0)</small></h2></td>
 			</tr>
 			<tr>
-				<td><h2><small>Smith-Waterman Alignment Score<span title="based on char-level comparison of best word-level match">*</span></small></h2></td>
+				<td><h2><small>Phrase (Smith-Waterman)</small></h2></td>
 				<td><h2><small>$sw_w_align_score</small></h2></td>
-			</tr>
-			<tr>
-				<td><h2><small>Composite Alignment Score<span title="char-level, Needleman-Wunsch primed with Smith-Waterman, number of chars highlighted dark green">*</span></small></h2></td>
-				<td><h2><small>$sw_nw_score</small></h2></td>
+				<td><h2><small>Approx. char. count of longest fuzzy overlap</small></h2></td>
 			</tr>
 		</table>
 	</span>
-	</br></br>
+</div>
+</br></br>

--- a/templates/docCompareInner.html
+++ b/templates/docCompareInner.html
@@ -53,7 +53,7 @@
 		</div>
 
 		<div class="col-md-4 text-center">
-		  <small>within <em>$doc_id_1_work_name</em> $text_1_doc_pos of $text_1_doc_count</small>
+		  <small>within <em>$doc_id_1_work_name</em>:<br>doc #$text_1_doc_pos of $text_1_doc_count</small>
 		</div>
 
 		<div class="col-md-2">
@@ -103,9 +103,7 @@
 		</div>
 
 		<div class="col-md-4 text-center">
-		  <small id="sim-status-left">
-			most similar #$sim_rank_of_1_for_2 of $N_sw_w for <em>$doc_id_2</em>
-		  </small>
+		  <small>for <em>$doc_id_2</em>:<br>most similar #$sim_rank_of_1_for_2 of $N_sw_w</small>
 		</div>
 
 		<div class="col-md-4 text-right">
@@ -168,7 +166,7 @@
 		</div>
 
 		<div class="col-md-4 text-center">
-		  <small>within <em>$doc_id_2_work_name</em> $text_2_doc_pos of $text_2_doc_count</small>
+		  <small>within <em>$doc_id_2_work_name</em>:<br>doc #$text_2_doc_pos of $text_2_doc_count</small>
 		</div>
 
 		<div class="col-md-2">
@@ -218,9 +216,7 @@
 		</div>
 
 		<div class="col-md-4 text-center">
-		  <small id="sim-status-right">
-			most similar #$sim_rank_of_2_for_1 of $N_sw_w for <em>$doc_id_1</em>
-		  </small>
+		  <small>for <em>$doc_id_1</em>:<br>most similar #$sim_rank_of_2_for_1 of $N_sw_w</small>
 		</div>
 
 		<div class="col-md-4 text-right">

--- a/templates/docCompareInner.html
+++ b/templates/docCompareInner.html
@@ -32,7 +32,7 @@
 					type="submit"
 					class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
 					data-doc-id="$first_doc_id_1"
-					title="Go to first passage ($first_doc_id_1)">
+					title="Go to first passage within $doc_id_1_work_name ($first_doc_id_1)">
 			  «
 			</button>
 		  </form>
@@ -46,7 +46,7 @@
 					type="submit"
 					class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
 					data-doc-id="$first_doc_id_1"
-					title="Go to previous passage ($prev_doc_id_1)">
+					title="Go to previous passage within $doc_id_1_work_name ($prev_doc_id_1)">
 			  ←
 			</button>
 		  </form>
@@ -64,7 +64,7 @@
 					type="submit"
 					class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
 					data-doc-id="$first_doc_id_1"
-					title="Go to next passage ($next_doc_id_1)">
+					title="Go to next passage within $doc_id_1_work_name ($next_doc_id_1)">
 			  →
 			</button>
 		  </form>
@@ -78,7 +78,7 @@
 					type="submit"
 					class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
 					data-doc-id="$first_doc_id_1"
-					title="Go to last passage ($last_doc_id_1)">
+					title="Go to last passage within $doc_id_1_work_name ($last_doc_id_1)">
 			  »
 			</button>
 		  </form>
@@ -96,7 +96,7 @@
 			<button id="sim-prev-btn-left"
 					type="submit"
 					class="btn btn-block btn-primary btn-no-outline"
-					title="Go to more similar (#$sim_rank_of_prev_for_2 of $N_sw_w)">
+					title="Go to more similar for $doc_id_2 (#$sim_rank_of_prev_for_2 of $N_sw_w)">
 			  ←
 			</button>
 		  </form>
@@ -113,7 +113,7 @@
 			<button id="sim-next-btn-left"
 					type="submit"
 					class="btn btn-block btn-primary btn-no-outline"
-					title="Go to less similar (#$sim_rank_of_next_for_2 of $N_sw_w)">
+					title="Go to less similar for $doc_id_2 (#$sim_rank_of_next_for_2 of $N_sw_w)">
 			  →
 			</button>
 		  </form>
@@ -145,7 +145,7 @@
 					type="submit"
 					class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
 					data-doc-id="$first_doc_id_2"
-					title="Go to first passage ($first_doc_id_2)">
+					title="Go to first passage within $doc_id_2_work_name ($first_doc_id_2)">
 			  «
 			</button>
 		  </form>
@@ -159,7 +159,7 @@
 					type="submit"
 					class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
 					data-doc-id="$first_doc_id_2"
-					title="Go to previous passage ($prev_doc_id_2)">
+					title="Go to previous passage within $doc_id_2_work_name ($prev_doc_id_2)">
 			  ←
 			</button>
 		  </form>
@@ -177,7 +177,7 @@
 					type="submit"
 					class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
 					data-doc-id="$first_doc_id_2"
-					title="Go to next passage ($next_doc_id_2)">
+					title="Go to next passage within $doc_id_2_work_name ($next_doc_id_2)">
 			  →
 			</button>
 		  </form>
@@ -191,7 +191,7 @@
 					type="submit"
 					class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
 					data-doc-id="$first_doc_id_2"
-					title="Go to last passage ($last_doc_id_2)">
+					title="Go to last passage within $doc_id_2_work_name ($last_doc_id_2)">
 			  »
 			</button>
 		  </form>
@@ -209,7 +209,7 @@
 			<button id="sim-prev-btn-right"
 					type="submit"
 					class="btn btn-block btn-primary btn-no-outline"
-					title="Go to more similar (#$sim_rank_of_prev_for_1 of $N_sw_w)">
+					title="Go to more similar for $doc_id_1 (#$sim_rank_of_prev_for_1 of $N_sw_w)">
 			  ←
 			</button>
 		  </form>
@@ -226,7 +226,7 @@
 			<button id="sim-next-btn-right"
 					type="submit"
 					class="btn btn-block btn-primary btn-no-outline"
-					title="Go to less similar (#$sim_rank_of_next_for_1 of $N_sw_w)">
+					title="Go to less similar for $doc_id_1 (#$sim_rank_of_next_for_1 of $N_sw_w)">
 			  →
 			</button>
 		  </form>
@@ -264,7 +264,7 @@
 			<tr>
 				<td><h2><small>Phrase (Smith-Waterman)</small></h2></td>
 				<td><h2><small>$sw_w_align_score</small></h2></td>
-				<td><h2><small>Approx. char. count of longest fuzzy overlap</small></h2></td>
+				<td><h2><small>Character count<span title="approximately, after factoring in fuzzy matching">*</span> of longest overlap</small></h2></td>
 			</tr>
 			<tr>
 				<td><h2><small>Word (TF-IDF)</small></h2></td>

--- a/templates/docExplore.html
+++ b/templates/docExplore.html
@@ -144,6 +144,33 @@
     </body>
 
 	<script type="text/javascript">
+		window.onload = function() {
+			// ─── DOCUMENT NAVIGATION: first/prev/next/last for left & right ─────────────────
+
+			const container = document.getElementById(`doc-explore-left`);
+			if (!container) return;
+
+			const current = container.dataset.current;
+			const first   = container.dataset.first;
+			const last    = container.dataset.last;
+
+			['first','prev','next','last'].forEach(type => {
+			  const btn = document.getElementById(`btn-${type}-explore`);
+			  if (!btn) return;
+
+			  // hide first & prev at the start
+			  if ((type === 'first' || type === 'prev') && current === first) {
+				btn.disabled = true;
+				btn.classList.add('disabled');
+			  }
+			  // hide next & last at the end
+			  if ((type === 'next' || type === 'last') && current === last) {
+				btn.disabled = true;
+				btn.classList.add('disabled');
+			  }
+			});
+		}
+
     	var abbrv2docs = {{ abbrv2docs|tojson|safe }};
     	var abbrev2title = {{ text_abbrev2title|tojson|safe }};
     	var section_labels = {{ section_labels|tojson|safe }};

--- a/templates/docExploreInner.html
+++ b/templates/docExploreInner.html
@@ -1,21 +1,72 @@
 <h1>$query_id <small><small>($query_section)</small></small></h1>
 
 <div class="row">
+    <div class="col-md-6" id="doc-explore-left"
+         data-current="$query_id_local"
+         data-first="$first_doc_id"
+         data-last="$last_doc_id">
 
-	<div class="col-md-2">
-		<form method="get" action="docExplore">
-			<input type="hidden" name="doc_id" value="$prev_doc_id" />
-			<input type="submit" class="btn btn-block btn-primary" value="<< $prev_doc_id" />
-		</form>
-	</div>
+        <!-- ─── 1) DOCUMENT NAVIGATION ON docExplore ───────────────────────────────── -->
+        <div class="row mb-2">
 
-	<div class="col-md-2">
-		<form method="get" action="docExplore">
-			<input type="hidden" name="doc_id" value="$next_doc_id" />
-			<input type="submit" class="btn btn-block btn-primary" value="$next_doc_id >>" />
-		</form>
-	</div>
+          <div class="col-md-2">
+            <form method="get" action="docExplore">
+              <input type="hidden" name="doc_id" value="${query_work_name}_${first_doc_id}"/>
+              <button id="btn-first-explore"
+                      type="submit"
+                      class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
+                      data-doc-id="$first_doc_id"
+                      title="Go to first passage within $query_work_name ($first_doc_id)">
+                «
+              </button>
+            </form>
+          </div>
 
+          <div class="col-md-2">
+            <form method="get" action="docExplore">
+              <input type="hidden" name="doc_id" value="${query_work_name}_${prev_doc_id}"/>
+              <button id="btn-prev-explore"
+                      type="submit"
+                      class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
+                      data-doc-id="$prev_doc_id"
+                      title="Go to previous passage within $query_work_name ($prev_doc_id)">
+                ‹
+              </button>
+            </form>
+          </div>
+
+          <div class="col-md-4 text-center">
+            <small>within <em>$query_work_name</em>:<br>doc #$query_text_pos of $query_text_doc_count</small>
+          </div>
+
+          <div class="col-md-2">
+            <form method="get" action="docExplore">
+              <input type="hidden" name="doc_id" value="${query_work_name}_${next_doc_id}"/>
+              <button id="btn-next-explore"
+                      type="submit"
+                      class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
+                      data-doc-id="$next_doc_id"
+                      title="Go to next passage within $query_work_name ($next_doc_id)">
+                ›
+              </button>
+            </form>
+          </div>
+
+          <div class="col-md-2">
+            <form method="get" action="docExplore">
+              <input type="hidden" name="doc_id" value="${query_work_name}_${last_doc_id}"/>
+              <button id="btn-last-explore"
+                      type="submit"
+                      class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
+                      data-doc-id="$last_doc_id"
+                      title="Go to last passage within $query_work_name ($last_doc_id)">
+                »
+              </button>
+            </form>
+          </div>
+
+        </div>
+    </div>
 </div>
 
 <div class="row">


### PR DESCRIPTION
- change way doc_links object created to eliminate wraparounds
- add first and last for intra-text (docExplore and docCompare)
- limit similarity results (docCompare) to much smaller `N_sw_w`
- add numbers to show positions in and size of lists for context
- make sure buttons are disabled appropriately
