### PR TITLE
chore: reduce search element top clutter (v1.0.17)

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-__app_version__ = "1.0.16"
+__app_version__ = "1.0.17"

--- a/templates/docCompare.html
+++ b/templates/docCompare.html
@@ -17,10 +17,6 @@
 
         <div class="container">
 
-
-        	<h1>Compare Docs</h1>
-        	<br>
-        	
 			<div class="row">
 
 				<form id="doc_compare_search_bar" action="/docCompare" method="POST">

--- a/templates/docCompareInner.html
+++ b/templates/docCompareInner.html
@@ -251,6 +251,8 @@
 
 </div>
 
+</br>
+
 <div class="row">
 
 	<span style="text-align: center;">
@@ -280,7 +282,7 @@
 	</span>
 </div>
 
-</br></br>
+</br>
 
 <div class="row">
 

--- a/templates/docExplore.html
+++ b/templates/docExplore.html
@@ -42,9 +42,11 @@
 							<option value="" size="15" selected="selected">Second doc id (batch mode only)</option>
 						</select>
 			        </div>
-			        <div class="col-md-2">
+			        <div class="col-md-1">
 			            <input id="doc_explore_submit_button" type="submit" class="btn btn-block btn-primary" value="Submit"/>
 			        </div>
+					<div class="col-md-1">
+					</div>
 			    </div>
 				<br>
 				<div class="row" id="sw_threshold_slider_row" style='display: none;'>

--- a/templates/docExplore.html
+++ b/templates/docExplore.html
@@ -23,7 +23,9 @@
 
         	<h1>Explore Docs</h1>
         	<br>
-        	
+
+			{% if not docExploreInner_HTML %}
+			<!-- SEARCH ELEMENTS -->
 			<form id="doc_explore_search_bar" action="/docExplore" method="POST">
 
 				<!-- input -->
@@ -68,6 +70,7 @@
 				</div>
 
 			</form>
+			{% endif %}
 
             {{ docExploreInner_HTML | safe }}
 

--- a/templates/docExplore.html
+++ b/templates/docExplore.html
@@ -26,7 +26,7 @@
 
 				<!-- input -->
 			    <div class="row">
-			    	<div class="col-md-2">
+			    	<div class="col-md-4">
 <!--			            <input id="doc_id" name="doc_id" type="text" class="form-control" placeholder="Enter doc id" size="30"/>-->
 						<select name="text_abbreviation_input" id="text_abbreviation_input" class="form-control">
 							<option value="" size="15" selected="selected">Select text</option>
@@ -34,34 +34,29 @@
 			        </div>
 					<div class="col-md-3">
 						<select name="local_doc_id_input" id="local_doc_id_input" class="form-control">
-							<option value="" size="15" selected="selected">Select query doc id</option>
+							<option value="" size="15" selected="selected">Select doc id</option>
 						</select>
 			        </div>
-			        <div class="col-md-1">
+					<div class="col-md-3">
+						<select name="local_doc_id_input_2" id="local_doc_id_input_2" class="form-control">
+							<option value="" size="15" selected="selected">Second doc id (batch mode only)</option>
+						</select>
+			        </div>
+			        <div class="col-md-2">
 			            <input id="doc_explore_submit_button" type="submit" class="btn btn-block btn-primary" value="Submit"/>
 			        </div>
 			    </div>
 				<br>
-				<div class="row">
-			    	<div class="col-md-2">
-			        </div>
-					<div class="col-md-3">
-						<select name="local_doc_id_input_2" id="local_doc_id_input_2" class="form-control">
-							<option value="" size="15" selected="selected">Subsequent doc id (batch mode)</option>
-						</select>
-			        </div>
-					<div class="col-md-1">
-			        </div>
-			    </div>
-				<br>
 				<div class="row" id="sw_threshold_slider_row" style='display: none;'>
-					<div class="col-md-2">
+					<div class="col-md-4">
 			        </div>
-					<div class="col-md-3" class="range">
+					<div class="col-md-5" class="range">
 						<input type="range" class="form-range" name="sw_threshold" id="sw_threshold" min="20" max="200" step="10" value="50"/>
 			        </div>
 					<div class="col-md-1">
 						<p id="sw_threshold_slider_label">sw score > 50</p>
+			        </div>
+					<div class="col-md-2">
 			        </div>
 				</div>
 
@@ -139,7 +134,7 @@
 	  		sw_threshold_slider_row.style.display = "block";
 	  	}
 
-	  	sw_threshold.onchange = function() {
+	  	sw_threshold.oninput = function() {
 	  		var sw_threshold_slider_label = document.getElementById("sw_threshold_slider_label");
 	  		sw_threshold_slider_label.innerHTML = `sw score > ` + sw_threshold.value;
 	  	}

--- a/templates/docExplore.html
+++ b/templates/docExplore.html
@@ -20,10 +20,6 @@
 
         <div class="container">
 
-
-        	<h1>Explore Docs</h1>
-        	<br>
-
 			{% if not docExploreInner_HTML %}
 			<!-- SEARCH ELEMENTS -->
 			<form id="doc_explore_search_bar" action="/docExplore" method="POST">

--- a/templates/textView.html
+++ b/templates/textView.html
@@ -17,8 +17,6 @@
 
         <div class="container">
 
-			<h1>View Text</h1>
-			<br>
 			<form id="textView_input" action="/textView" method="POST">
 
 				<!-- input -->


### PR DESCRIPTION
The three main pages, especially docExplore, and to a lesser extent docCompare (and textView), had too much stuff on top.

- remove headers
- slim down docExplore search elements to one line like the other two modes
- suppress docExplore search elements entirely once viewing content