### PR TITLE
feat(docExplore): add toggle for original/segmented text (v1.1.0)

### DIFF
--- a/IR_tools.py
+++ b/IR_tools.py
@@ -767,6 +767,7 @@ def get_closest_docs(   query_id,
                         similarity_data: Optional[PymongoCollection]=None,
                         batch_mode: Optional[bool]=False,
                         sw_w_min_threshold: Optional[int]=50,
+                        text_type_toggle_choice="original",
                         ):
 
     non_priority_texts = [text for text in list(text_abbrev2fn.keys()) if text not in priority_texts]
@@ -799,6 +800,7 @@ def get_closest_docs(   query_id,
             secondary_results_list_content = '',
             priority_texts=str(priority_texts),
             non_priority_texts=str(non_priority_texts),
+            text_type_toggle_choice=text_type_toggle_choice,
             )
         return results_HTML
 
@@ -1015,7 +1017,8 @@ def get_closest_docs(   query_id,
                             priority_col_content = priority_col_HTML,
                             secondary_col_content = secondary_col_HTML,
                             priority_texts=str(priority_texts),
-                            non_priority_texts=str(non_priority_texts)
+                            non_priority_texts=str(non_priority_texts),
+                            text_type_toggle_choice=text_type_toggle_choice,
                             )
 
     # import pdb; pdb.set_trace()

--- a/IR_tools.py
+++ b/IR_tools.py
@@ -767,7 +767,7 @@ def get_closest_docs(   query_id,
                         similarity_data: Optional[PymongoCollection]=None,
                         batch_mode: Optional[bool]=False,
                         sw_w_min_threshold: Optional[int]=50,
-                        text_type_toggle_choice="original",
+                        text_type_toggle="original",
                         ):
 
     non_priority_texts = [text for text in list(text_abbrev2fn.keys()) if text not in priority_texts]
@@ -800,7 +800,7 @@ def get_closest_docs(   query_id,
             secondary_results_list_content = '',
             priority_texts=str(priority_texts),
             non_priority_texts=str(non_priority_texts),
-            text_type_toggle_choice=text_type_toggle_choice,
+            text_type_toggle=text_type_toggle,
             )
         return results_HTML
 
@@ -1018,7 +1018,7 @@ def get_closest_docs(   query_id,
                             secondary_col_content = secondary_col_HTML,
                             priority_texts=str(priority_texts),
                             non_priority_texts=str(non_priority_texts),
-                            text_type_toggle_choice=text_type_toggle_choice,
+                            text_type_toggle=text_type_toggle,
                             )
 
     # import pdb; pdb.set_trace()

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-__app_version__ = "1.0.17"
+__app_version__ = "1.1.0"

--- a/flask_app.py
+++ b/flask_app.py
@@ -161,12 +161,10 @@ def doc_explore():
             doc_id_2 = text_id_list[-1]
 
         if 'text_type_toggle' in request.args:
-            text_type_toggle_choice = request.args.get("text_type_toggle")
-            session["text_type_toggle"] = text_type_toggle_choice
+            session["text_type_toggle"] = request.args.get("text_type_toggle")
             session.modified = True
         elif 'text_type_toggle' in request.form:
-            text_type_toggle_choice = request.form.get("text_type_toggle")
-            session["text_type_toggle"] = text_type_toggle_choice
+            session["text_type_toggle"] = request.form.get("text_type_toggle")
             session.modified = True
 
         valid_doc_ids = IR_tools.doc_ids
@@ -196,7 +194,7 @@ def doc_explore():
                     N_tf_idf=session["N_tf_idf"],
                     N_sw_w=session["N_sw_w"],
                     similarity_data=similarity_data,
-                    text_type_toggle_choice=session["text_type_toggle"],
+                    text_type_toggle=session["text_type_toggle"],
                 )
         else:
             docExploreInner_HTML = "<br><p>Please verify sequence of two inputs.</p>"

--- a/flask_app.py
+++ b/flask_app.py
@@ -69,6 +69,7 @@ flask_session_variable_names = [
     "topic_labels",
     "priority_texts",
     "N_tf_idf", "N_sw_w",
+    "text_type_toggle"
     ]
 
 def ensure_keys():
@@ -85,6 +86,7 @@ def reset_variables():
     session["priority_texts"] = list(IR_tools.text_abbrev2fn.keys())
     session["N_tf_idf"] = IR_tools.search_N_defaults["N_tf_idf"]
     session["N_sw_w"] = IR_tools.search_N_defaults["N_sw_w"]
+    session["text_type_toggle"] = "original"
     session.modified = True
     return redirect(url_for('index'))
 
@@ -158,6 +160,15 @@ def doc_explore():
             doc_id = text_id_list[0]
             doc_id_2 = text_id_list[-1]
 
+        if 'text_type_toggle' in request.args:
+            text_type_toggle_choice = request.args.get("text_type_toggle")
+            session["text_type_toggle"] = text_type_toggle_choice
+            session.modified = True
+        elif 'text_type_toggle' in request.form:
+            text_type_toggle_choice = request.form.get("text_type_toggle")
+            session["text_type_toggle"] = text_type_toggle_choice
+            session.modified = True
+
         valid_doc_ids = IR_tools.doc_ids
         if (
                 doc_id in valid_doc_ids
@@ -185,7 +196,8 @@ def doc_explore():
                     N_tf_idf=session["N_tf_idf"],
                     N_sw_w=session["N_sw_w"],
                     similarity_data=similarity_data,
-                    )
+                    text_type_toggle_choice=session["text_type_toggle"],
+                )
         else:
             docExploreInner_HTML = "<br><p>Please verify sequence of two inputs.</p>"
                                    # "Please enter valid doc ids like " + str(IR_tools.ex_doc_ids)[1:-1] + " etc.</p><p>See <a href='assets/doc_id_list.txt' target='_blank'>doc id list</a> and <a href='assets/corpus_texts.txt' target='_blank'>corpus text list</a> for hints to get started."

--- a/templates/docExploreInner.html
+++ b/templates/docExploreInner.html
@@ -1,4 +1,10 @@
-<h1>$query_id <small><small>($query_section)</small></small></h1>
+<div class="row">
+  <div class="col-md-12">
+    <h1 style="margin-top: 0px; margin-bottom: 10px;">
+      $query_id <small><small>($query_section)</small></small>
+    </h1>
+  </div>
+</div>
 
 <div class="col-md-6" id="doc-explore-left"
      data-current="$query_id_local"
@@ -11,6 +17,7 @@
       <div class="col-md-2">
         <form method="get" action="docExplore">
           <input type="hidden" name="doc_id" value="${query_work_name}_${first_doc_id}"/>
+          <input type="hidden" name="text_type_toggle" id="text_type_toggle_input_first" value="$text_type_toggle_choice" />
           <button id="btn-first-explore"
                   type="submit"
                   class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
@@ -24,6 +31,7 @@
       <div class="col-md-2">
         <form method="get" action="docExplore">
           <input type="hidden" name="doc_id" value="${query_work_name}_${prev_doc_id}"/>
+          <input type="hidden" name="text_type_toggle" id="text_type_toggle_input_prev" value="$text_type_toggle_choice" />
           <button id="btn-prev-explore"
                   type="submit"
                   class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
@@ -41,6 +49,7 @@
       <div class="col-md-2">
         <form method="get" action="docExplore">
           <input type="hidden" name="doc_id" value="${query_work_name}_${next_doc_id}"/>
+          <input type="hidden" name="text_type_toggle" id="text_type_toggle_input_next" value="$text_type_toggle_choice" />
           <button id="btn-next-explore"
                   type="submit"
                   class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
@@ -54,6 +63,7 @@
       <div class="col-md-2">
         <form method="get" action="docExplore">
           <input type="hidden" name="doc_id" value="${query_work_name}_${last_doc_id}"/>
+          <input type="hidden" name="text_type_toggle" id="text_type_toggle_input_last" value="$text_type_toggle_choice" />
           <button id="btn-last-explore"
                   type="submit"
                   class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
@@ -66,8 +76,11 @@
 
     </div>
 
+    <!-- NEUTRAL DUMMY INPUT FOR JS TO READ FROM ON PAGE LOAD -->
+    <input type="hidden" id="text_type_toggle_value" value="$text_type_toggle_choice">
+
     <!-- TEXT TYPE TOGGLE BLOCK -->
-    <div class="panel panel-default" style="margin-bottom: 10px;">
+    <div class="panel panel-default" style="margin-top: 30px">
       <div class="panel-body" style="padding: 10px;">
 
         <div class="btn-toolbar" style="margin: 0 0 10px 0;">
@@ -90,7 +103,7 @@
 
     <!-- 3) TOPIC ANALYSIS -->
 	<div class="col-md-6 mb-5">
-		<h2 class="mb-3">Topic Analysis</h2>
+		<h3 class="mb-3" style="margin-bottom: 0px;">Topic Analysis</h3>
 		<img id="plot" src="/assets/doc_plot_pngs/$query_id.png" alt="oops" width="550" height="385">
 		$top_topics_summary
 	</div>
@@ -101,11 +114,11 @@
 
 <div class="col-md-6 mb-5" id="doc-explore-right">
 
-    <div>
-        <h2 class="mb-3">Similar Docs of Priority Texts<span title="$priority_texts">*</span></h2>
-        <br>
-        $priority_col_content
-    </div>
+    <h3 class="mb-3" style="margin-top: 0px; margin-bottom: 0px;">
+      Similar Docs of Priority Texts<span title="$priority_texts">*</span>
+    </h3>
+    <br>
+    $priority_col_content
 
     <br><br>
 
@@ -135,19 +148,43 @@
     const container = document.getElementById('text-container');
     const btnOrig   = document.getElementById('btn-original');
     const btnSeg    = document.getElementById('btn-segmented');
+    const hiddenInputs = document.querySelectorAll('input[name="text_type_toggle"]');
+
+    // read the passed value from the hidden input
+    const initialToggle = document.getElementById('text_type_toggle_value').value;
+
+    function updateHiddenInputs(value) {
+        hiddenInputs.forEach(input => input.value = value);
+    }
 
     function show(which) {
-      container.innerHTML = (which === 'orig') ? originalHTML : segmentedHTML;
-
-      // toggle filled / outline look
-      btnOrig.classList.toggle('btn-primary',   which === 'orig');
-      btnOrig.classList.toggle('btn-outline-primary', which !== 'orig');
-      btnSeg .classList.toggle('btn-primary',   which === 'seg');
-      btnSeg .classList.toggle('btn-outline-primary', which !== 'seg');
+        if (which === 'orig') {
+            container.innerHTML = originalHTML;
+            btnOrig.classList.replace('btn-default','btn-primary');
+            btnSeg .classList.replace('btn-primary','btn-default');
+            updateHiddenInputs('original');
+        } else {
+            container.innerHTML = segmentedHTML;
+            btnSeg .classList.replace('btn-default','btn-primary');
+            btnOrig.classList.replace('btn-primary','btn-default');
+            updateHiddenInputs('segmented');
+        }
     }
 
     btnOrig.addEventListener('click', () => show('orig'));
     btnSeg .addEventListener('click', () => show('seg'));
 
-    show('orig');   // initial load
+    // initial load
+    show(initialToggle === 'segmented' ? 'seg' : 'orig');
+
+  // Before any form submits, remove unnecessary hidden fields
+  document.querySelectorAll('form').forEach(form => {
+      form.addEventListener('submit', () => {
+          const toggleInput = form.querySelector('input[name="text_type_toggle"]');
+          if (toggleInput && toggleInput.value === initialToggle) {
+              toggleInput.parentNode.removeChild(toggleInput);
+          }
+      });
+  });
+
 </script>

--- a/templates/docExploreInner.html
+++ b/templates/docExploreInner.html
@@ -66,30 +66,27 @@
 
     </div>
 
-<!-- TEXT TYPE TOGGLE BLOCK -->
-<div class="panel panel-default" style="margin-bottom: 10px;">
-  <div class="panel-body" style="padding: 5px 10px;">
+    <!-- TEXT TYPE TOGGLE BLOCK -->
+    <div class="panel panel-default" style="margin-bottom: 10px;">
+      <div class="panel-body" style="padding: 10px;">
 
-    <div class="btn-toolbar" style="margin: 0;">
-      <div class="btn-group" style="margin-right: 10px; vertical-align: middle;">
-        <strong style="line-height: 30px;">Text type:</strong>
-      </div>
-      <div class="btn-group btn-group-sm">
-        <button id="btn-original"  class="btn btn-primary btn-sm">Original</button>
-        <button id="btn-segmented" class="btn btn-default btn-sm">Segmented</button>
+        <div class="btn-toolbar" style="margin: 0 0 10px 0;">
+          <div class="btn-group" style="margin-right: 10px; vertical-align: middle;">
+            <strong style="line-height: 30px;">Text type:</strong>
+          </div>
+          <div class="btn-group btn-group-sm">
+            <button id="btn-original"  class="btn btn-primary btn-sm">Original</button>
+            <button id="btn-segmented" class="btn btn-default btn-sm">Segmented</button>
+          </div>
+        </div>
+
+        <!-- TEXT CONTAINER -->
+        <div id="text-container">
+        <!-- JS will inject the text here -->
+        </div>
+
       </div>
     </div>
-
-  </div>
-</div>
-
-<!-- TEXT CONTAINER -->
-<div class="panel panel-default">
-  <div id="text-container" class="panel-body">
-    <!-- JS will inject the text here -->
-  </div>
-</div>
-
 
     <!-- 3) TOPIC ANALYSIS -->
 	<div class="col-md-6 mb-5">

--- a/templates/docExploreInner.html
+++ b/templates/docExploreInner.html
@@ -1,115 +1,124 @@
 <h1>$query_id <small><small>($query_section)</small></small></h1>
 
-<div class="row">
-    <div class="col-md-6" id="doc-explore-left"
-         data-current="$query_id_local"
-         data-first="$first_doc_id"
-         data-last="$last_doc_id">
+<div class="col-md-6" id="doc-explore-left"
+     data-current="$query_id_local"
+     data-first="$first_doc_id"
+     data-last="$last_doc_id">
 
-        <!-- ─── 1) DOCUMENT NAVIGATION ON docExplore ───────────────────────────────── -->
-        <div class="row mb-2">
+    <!-- ─── 1) DOCUMENT NAVIGATION ON docExplore ───────────────────────────────── -->
+    <div class="row align-items-center g-2 mb-4">
 
-          <div class="col-md-2">
-            <form method="get" action="docExplore">
-              <input type="hidden" name="doc_id" value="${query_work_name}_${first_doc_id}"/>
-              <button id="btn-first-explore"
-                      type="submit"
-                      class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
-                      data-doc-id="$first_doc_id"
-                      title="Go to first passage within $query_work_name ($first_doc_id)">
-                «
-              </button>
-            </form>
-          </div>
+      <div class="col-md-2">
+        <form method="get" action="docExplore">
+          <input type="hidden" name="doc_id" value="${query_work_name}_${first_doc_id}"/>
+          <button id="btn-first-explore"
+                  type="submit"
+                  class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
+                  data-doc-id="$first_doc_id"
+                  title="Go to first passage within $query_work_name ($first_doc_id)">
+            «
+          </button>
+        </form>
+      </div>
 
-          <div class="col-md-2">
-            <form method="get" action="docExplore">
-              <input type="hidden" name="doc_id" value="${query_work_name}_${prev_doc_id}"/>
-              <button id="btn-prev-explore"
-                      type="submit"
-                      class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
-                      data-doc-id="$prev_doc_id"
-                      title="Go to previous passage within $query_work_name ($prev_doc_id)">
-                ‹
-              </button>
-            </form>
-          </div>
+      <div class="col-md-2">
+        <form method="get" action="docExplore">
+          <input type="hidden" name="doc_id" value="${query_work_name}_${prev_doc_id}"/>
+          <button id="btn-prev-explore"
+                  type="submit"
+                  class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
+                  data-doc-id="$prev_doc_id"
+                  title="Go to previous passage within $query_work_name ($prev_doc_id)">
+            ‹
+          </button>
+        </form>
+      </div>
 
-          <div class="col-md-4 text-center">
-            <small>within <em>$query_work_name</em>:<br>doc #$query_text_pos of $query_text_doc_count</small>
-          </div>
+      <div class="col-md-4 text-center">
+        <small>within <em>$query_work_name</em>:<br>doc #$query_text_pos of $query_text_doc_count</small>
+      </div>
 
-          <div class="col-md-2">
-            <form method="get" action="docExplore">
-              <input type="hidden" name="doc_id" value="${query_work_name}_${next_doc_id}"/>
-              <button id="btn-next-explore"
-                      type="submit"
-                      class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
-                      data-doc-id="$next_doc_id"
-                      title="Go to next passage within $query_work_name ($next_doc_id)">
-                ›
-              </button>
-            </form>
-          </div>
+      <div class="col-md-2">
+        <form method="get" action="docExplore">
+          <input type="hidden" name="doc_id" value="${query_work_name}_${next_doc_id}"/>
+          <button id="btn-next-explore"
+                  type="submit"
+                  class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
+                  data-doc-id="$next_doc_id"
+                  title="Go to next passage within $query_work_name ($next_doc_id)">
+            ›
+          </button>
+        </form>
+      </div>
 
-          <div class="col-md-2">
-            <form method="get" action="docExplore">
-              <input type="hidden" name="doc_id" value="${query_work_name}_${last_doc_id}"/>
-              <button id="btn-last-explore"
-                      type="submit"
-                      class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
-                      data-doc-id="$last_doc_id"
-                      title="Go to last passage within $query_work_name ($last_doc_id)">
-                »
-              </button>
-            </form>
-          </div>
+      <div class="col-md-2">
+        <form method="get" action="docExplore">
+          <input type="hidden" name="doc_id" value="${query_work_name}_${last_doc_id}"/>
+          <button id="btn-last-explore"
+                  type="submit"
+                  class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
+                  data-doc-id="$last_doc_id"
+                  title="Go to last passage within $query_work_name ($last_doc_id)">
+            »
+          </button>
+        </form>
+      </div>
 
-        </div>
     </div>
+
+<!-- TEXT TYPE TOGGLE BLOCK -->
+<div class="panel panel-default" style="margin-bottom: 10px;">
+  <div class="panel-body" style="padding: 5px 10px;">
+
+    <div class="btn-toolbar" style="margin: 0;">
+      <div class="btn-group" style="margin-right: 10px; vertical-align: middle;">
+        <strong style="line-height: 30px;">Text type:</strong>
+      </div>
+      <div class="btn-group btn-group-sm">
+        <button id="btn-original"  class="btn btn-primary btn-sm">Original</button>
+        <button id="btn-segmented" class="btn btn-default btn-sm">Segmented</button>
+      </div>
+    </div>
+
+  </div>
 </div>
 
-<div class="row">
-
-	<div class="col-md-6">
-		<h2>Original Text</h2>
-		<p>$query_original_fulltext</p>
-	</div>
-
-	<div class="col-md-6">
-		<h2>Segmented Text</h2>
-		<p>$query_segmented_fulltext</p>
-	</div>
-
+<!-- TEXT CONTAINER -->
+<div class="panel panel-default">
+  <div id="text-container" class="panel-body">
+    <!-- JS will inject the text here -->
+  </div>
 </div>
 
-<div class="row">
 
-	<div class="col-md-6">
-		<h2>Topic Analysis</h2>
+    <!-- 3) TOPIC ANALYSIS -->
+	<div class="col-md-6 mb-5">
+		<h2 class="mb-3">Topic Analysis</h2>
 		<img id="plot" src="/assets/doc_plot_pngs/$query_id.png" alt="oops" width="550" height="385">
 		$top_topics_summary
 	</div>
 
-	<div class="col-md-6">
+    <br><br>
 
-		<div>
-			<h2>Similar<span title="by topic, tf-idf">*</span> Docs of Priority Texts<span title="$priority_texts">*</span></h2>
-			<br>
-			$priority_col_content
-		</div>
+</div>
 
-		<br><br>
+<div class="col-md-6 mb-5" id="doc-explore-right">
 
-		<button class="btn btn-block btn-primary" onclick="show_secondary()">Show Non-Priority Results</button>
+    <div>
+        <h2 class="mb-3">Similar Docs of Priority Texts<span title="$priority_texts">*</span></h2>
+        <br>
+        $priority_col_content
+    </div>
 
-		<div id="secondary_col_div" style='display: none;'>
-			<h2>Similar<span title="by topic">*</span> Docs of Non-Priority Texts<span title="$non_priority_texts">*</span></h2>
-			<br>
-			$secondary_col_content
-		</div>
+    <br><br>
 
-	</div>
+<!--    <button class="btn btn-block btn-primary" onclick="show_secondary()">Show Non-Priority Results</button>-->
+
+<!--    <div id="secondary_col_div" style='display: none;'>-->
+<!--        <h2>Similar<span title="by topic">*</span> Docs of Non-Priority Texts<span title="$non_priority_texts">*</span></h2>-->
+<!--        <br>-->
+<!--        $secondary_col_content-->
+<!--    </div>-->
 
 </div>
 
@@ -118,4 +127,30 @@
 	  var secondary_col_div = document.getElementById("secondary_col_div");
 	  secondary_col_div.style.display = "block";
 	}
+
+    // original-segmented toggle
+
+    // grab your two chunks of HTML (in your template engine these will be expanded in‐place)
+    const originalHTML = `<p>$query_original_fulltext</p>`;
+    const segmentedHTML = `<p>$query_segmented_fulltext</p>`;
+
+    // cache DOM nodes
+    const container = document.getElementById('text-container');
+    const btnOrig   = document.getElementById('btn-original');
+    const btnSeg    = document.getElementById('btn-segmented');
+
+    function show(which) {
+      container.innerHTML = (which === 'orig') ? originalHTML : segmentedHTML;
+
+      // toggle filled / outline look
+      btnOrig.classList.toggle('btn-primary',   which === 'orig');
+      btnOrig.classList.toggle('btn-outline-primary', which !== 'orig');
+      btnSeg .classList.toggle('btn-primary',   which === 'seg');
+      btnSeg .classList.toggle('btn-outline-primary', which !== 'seg');
+    }
+
+    btnOrig.addEventListener('click', () => show('orig'));
+    btnSeg .addEventListener('click', () => show('seg'));
+
+    show('orig');   // initial load
 </script>

--- a/templates/docExploreInner.html
+++ b/templates/docExploreInner.html
@@ -11,13 +11,13 @@
      data-first="$first_doc_id"
      data-last="$last_doc_id">
 
-    <!-- ─── 1) DOCUMENT NAVIGATION ON docExplore ───────────────────────────────── -->
+    <!-- ─── 1) DOCUMENT NAVIGATION ───────────────────────────────── -->
     <div class="row align-items-center g-2 mb-4">
 
       <div class="col-md-2">
         <form method="get" action="docExplore">
           <input type="hidden" name="doc_id" value="${query_work_name}_${first_doc_id}"/>
-          <input type="hidden" name="text_type_toggle" id="text_type_toggle_input_first" value="$text_type_toggle_choice" />
+          <input type="hidden" name="text_type_toggle" id="text_type_toggle_input_first" value="$text_type_toggle" />
           <button id="btn-first-explore"
                   type="submit"
                   class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
@@ -31,7 +31,7 @@
       <div class="col-md-2">
         <form method="get" action="docExplore">
           <input type="hidden" name="doc_id" value="${query_work_name}_${prev_doc_id}"/>
-          <input type="hidden" name="text_type_toggle" id="text_type_toggle_input_prev" value="$text_type_toggle_choice" />
+          <input type="hidden" name="text_type_toggle" id="text_type_toggle_input_prev" value="$text_type_toggle" />
           <button id="btn-prev-explore"
                   type="submit"
                   class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
@@ -49,7 +49,7 @@
       <div class="col-md-2">
         <form method="get" action="docExplore">
           <input type="hidden" name="doc_id" value="${query_work_name}_${next_doc_id}"/>
-          <input type="hidden" name="text_type_toggle" id="text_type_toggle_input_next" value="$text_type_toggle_choice" />
+          <input type="hidden" name="text_type_toggle" id="text_type_toggle_input_next" value="$text_type_toggle" />
           <button id="btn-next-explore"
                   type="submit"
                   class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
@@ -63,7 +63,7 @@
       <div class="col-md-2">
         <form method="get" action="docExplore">
           <input type="hidden" name="doc_id" value="${query_work_name}_${last_doc_id}"/>
-          <input type="hidden" name="text_type_toggle" id="text_type_toggle_input_last" value="$text_type_toggle_choice" />
+          <input type="hidden" name="text_type_toggle" id="text_type_toggle_input_last" value="$text_type_toggle" />
           <button id="btn-last-explore"
                   type="submit"
                   class="btn btn-block btn-primary btn-no-outline doc-nav-btn"
@@ -77,9 +77,9 @@
     </div>
 
     <!-- NEUTRAL DUMMY INPUT FOR JS TO READ FROM ON PAGE LOAD -->
-    <input type="hidden" id="text_type_toggle_value" value="$text_type_toggle_choice">
+    <input type="hidden" id="text_type_toggle_value" value="$text_type_toggle">
 
-    <!-- TEXT TYPE TOGGLE BLOCK -->
+    <!-- TEXT TYPE TOGGLE -->
     <div class="panel panel-default" style="margin-top: 30px">
       <div class="panel-body" style="padding: 10px;">
 
@@ -112,6 +112,7 @@
 
 </div>
 
+<!-- SIMILARITY RESULTS -->
 <div class="col-md-6 mb-5" id="doc-explore-right">
 
     <h3 class="mb-3" style="margin-top: 0px; margin-bottom: 0px;">
@@ -140,17 +141,14 @@
 
     // original-segmented toggle
 
-    // grab your two chunks of HTML (in your template engine these will be expanded in‐place)
     const originalHTML = `<p>$query_original_fulltext</p>`;
     const segmentedHTML = `<p>$query_segmented_fulltext</p>`;
-
-    // cache DOM nodes
     const container = document.getElementById('text-container');
     const btnOrig   = document.getElementById('btn-original');
     const btnSeg    = document.getElementById('btn-segmented');
     const hiddenInputs = document.querySelectorAll('input[name="text_type_toggle"]');
 
-    // read the passed value from the hidden input
+    // read passed value from hidden input
     const initialToggle = document.getElementById('text_type_toggle_value').value;
 
     function updateHiddenInputs(value) {
@@ -177,14 +175,13 @@
     // initial load
     show(initialToggle === 'segmented' ? 'seg' : 'orig');
 
-  // Before any form submits, remove unnecessary hidden fields
-  document.querySelectorAll('form').forEach(form => {
-      form.addEventListener('submit', () => {
-          const toggleInput = form.querySelector('input[name="text_type_toggle"]');
-          if (toggleInput && toggleInput.value === initialToggle) {
-              toggleInput.parentNode.removeChild(toggleInput);
-          }
-      });
-  });
-
+    // Before any form submits, remove unnecessary hidden fields
+    document.querySelectorAll('form').forEach(form => {
+        form.addEventListener('submit', () => {
+            const toggleInput = form.querySelector('input[name="text_type_toggle"]');
+            if (toggleInput && toggleInput.value === initialToggle) {
+                toggleInput.parentNode.removeChild(toggleInput);
+            }
+        });
+    });
 </script>

--- a/templates/docExploreInner.html
+++ b/templates/docExploreInner.html
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-md-12">
-    <h1 style="margin-top: 0px; margin-bottom: 10px;">
+    <h1 style="margin-top: 0px">
       $query_id <small><small>($query_section)</small></small>
     </h1>
   </div>
@@ -80,7 +80,7 @@
     <input type="hidden" id="text_type_toggle_value" value="$text_type_toggle">
 
     <!-- TEXT TYPE TOGGLE -->
-    <div class="panel panel-default" style="margin-top: 30px">
+    <div class="panel panel-default">
       <div class="panel-body" style="padding: 10px;">
 
         <div class="btn-toolbar" style="margin: 0 0 10px 0;">


### PR DESCRIPTION
Toggle is slick, functional, and works via the session. Only changes are registered on form submission (they appear in the URL).

May do something similar for docCompare later, but not yet.

Also improved docExplore layout to maximize working space. Very nice result.

Before:
<img width="1181" alt="Screenshot 2025-05-06 at 22 46 33" src="https://github.com/user-attachments/assets/d9fbacba-11c8-4c5d-bc91-e384fefd341f"/>

After:
<img width="1230" alt="Screenshot 2025-05-06 at 23 00 58" src="https://github.com/user-attachments/assets/d9ce85c7-d900-41ff-bc0a-caeb85578fbd" />
