### PR TITLE
fix: reduce docCompare bot traffic, part 1 (v1.2.1.0)

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-__app_version__ = "1.2.0"
+__app_version__ = "1.2.1.0"

--- a/assets/robots.txt
+++ b/assets/robots.txt
@@ -1,3 +1,2 @@
-# https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow: /
+Disallow: /docCompare


### PR DESCRIPTION
Just adjust `robots.txt` for now.

Next step is hiding `docCompare` links behind JavaScript. The idea is (from Gemini CLI):

"""
 1. Simple Crawlers and Scrapers: A very large percentage of automated traffic comes from simple bots. These are built for speed and efficiency, so they only read the raw HTML of a page. They do not execute JavaScript because it's computationally expensive. Our JavaScript-based solution is highly effective against this entire class of bots. These are often the ones that ignore robots.txt and cause high-volume, "junk" traffic.

2. Sophisticated Crawlers (like Googlebot): Major search engine crawlers are designed to see a page exactly as a user does. They have rendering engines that execute JavaScript. Our solution will not hide the links from these bots.

However, this is why we used a two-part defense:

- The `robots.txt` file is our instruction to the sophisticated, well-behaved crawlers like Googlebot. They will see the Disallow: /docCompare rule and will not crawl those URLs.
- The JavaScript obfuscation is our defense against the simple, ill-behaved crawlers who ignore robots.txt but can't process JavaScript.

"""

I.e., doing number 2 first.