### PR TITLE
fix: reduce docCompare bot traffic, part 2 (v1.2.1.1)

### DIFF
--- a/Dockerfile.stg
+++ b/Dockerfile.stg
@@ -9,5 +9,5 @@ COPY --chown=sanskrit:appgroup templates /app/templates
 COPY --chown=sanskrit:appgroup ./*.py /app/
 COPY --chown=sanskrit:appgroup ./VERSION /app/
 USER sanskrit
-CMD gunicorn --bind 0.0.0.0:5020 --log-level info --error-logfile - flask_app:app
-EXPOSE 5020
+CMD gunicorn --bind 0.0.0.0:5021 --log-level info --error-logfile - flask_app:app
+EXPOSE 5021

--- a/IR_tools.py
+++ b/IR_tools.py
@@ -543,7 +543,7 @@ def format_textView_link(doc_id):
 def format_docCompare_link(doc_id_1, doc_id_2, display_string="dcCp", title=""):
     # each one looks like fixed string "dcCp" unless otherwise specified
     # return "<a href='docCompare?doc_id_1=%s&doc_id_2=%s' target='docCompare' title='%s'>%s</a>" % (doc_id_1, doc_id_2, title, display_string)
-    return f"<a class='doc-compare-link' data-doc1='{doc_id_1}' data-doc2='{doc_id_2}' target='docCompare' title='{title}' style='cursor:pointer; text-decoration:underline; color:#007bff;'>{display_string}</a>"
+    return f"<a class='doc-compare-link' data-doc1='{doc_id_1}' data-doc2='{doc_id_2}' target='docCompare' title='{title}' style='cursor:pointer; text-decoration:underline;'>{display_string}</a>"
 
 def format_similarity_result(query_id, selected_results_list_content):
 

--- a/IR_tools.py
+++ b/IR_tools.py
@@ -542,7 +542,8 @@ def format_textView_link(doc_id):
 
 def format_docCompare_link(doc_id_1, doc_id_2, display_string="dcCp", title=""):
     # each one looks like fixed string "dcCp" unless otherwise specified
-    return "<a href='docCompare?doc_id_1=%s&doc_id_2=%s' target='docCompare' title='%s'>%s</a>" % (doc_id_1, doc_id_2, title, display_string)
+    # return "<a href='docCompare?doc_id_1=%s&doc_id_2=%s' target='docCompare' title='%s'>%s</a>" % (doc_id_1, doc_id_2, title, display_string)
+    return f"<a class='doc-compare-link' data-doc1='{doc_id_1}' data-doc2='{doc_id_2}' target='docCompare' title='{title}' style='cursor:pointer; text-decoration:underline; color:#007bff;'>{display_string}</a>"
 
 def format_similarity_result(query_id, selected_results_list_content):
 

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-__app_version__ = "1.2.1.0"
+__app_version__ = "1.2.1.1"

--- a/templates/docExplore.html
+++ b/templates/docExplore.html
@@ -212,6 +212,24 @@
 
     </script>
 
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        document.body.addEventListener('click', function(event) {
+            const link = event.target.closest('.doc-compare-link');
+            if (link) {
+                event.preventDefault();
+                event.stopPropagation();
+                const doc1 = link.getAttribute('data-doc1');
+                const doc2 = link.getAttribute('data-doc2');
+                if (doc1 && doc2) {
+                    const url = `docCompare?doc_id_1=${doc1}&doc_id_2=${doc2}`;
+                    window.open(url, link.getAttribute('target') || '_self');
+                }
+            }
+        }, true); // Using capture phase
+    });
+    </script>
+
 	</body>
 
 </html>


### PR DESCRIPTION
Cp. #42 

This part hides `docCompare` links behind JS.

Scout chore: multiple Dockerfiles.