### PR TITLE
Claude rescue (v1.3.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,5 @@ COPY --chown=sanskrit:appgroup templates /app/templates
 COPY --chown=sanskrit:appgroup ./*.py /app/
 COPY --chown=sanskrit:appgroup ./VERSION /app/
 USER sanskrit
-CMD gunicorn --bind 0.0.0.0:5020 --log-level info --error-logfile - flask_app:app
+CMD gunicorn --bind 0.0.0.0:5020 --workers 2 --threads 2 --timeout 120 --max-requests 1000 --max-requests-jitter 50 --log-level info --error-logfile - flask_app:app
 EXPOSE 5020

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,5 @@ COPY --chown=sanskrit:appgroup templates /app/templates
 COPY --chown=sanskrit:appgroup ./*.py /app/
 COPY --chown=sanskrit:appgroup ./VERSION /app/
 USER sanskrit
-CMD gunicorn --bind 0.0.0.0:5020 --workers 2 --threads 2 --timeout 120 --max-requests 1000 --max-requests-jitter 50 --log-level info --error-logfile - flask_app:app
+CMD gunicorn --bind 0.0.0.0:5020 --workers 2 --threads 5 --timeout 120 --max-requests 1000 --max-requests-jitter 50 --log-level info --error-logfile - flask_app:app
 EXPOSE 5020

--- a/Dockerfile.stg
+++ b/Dockerfile.stg
@@ -9,5 +9,5 @@ COPY --chown=sanskrit:appgroup templates /app/templates
 COPY --chown=sanskrit:appgroup ./*.py /app/
 COPY --chown=sanskrit:appgroup ./VERSION /app/
 USER sanskrit
-CMD gunicorn --bind 0.0.0.0:5021 --log-level info --error-logfile - flask_app:app
+CMD gunicorn --bind 0.0.0.0:5021 --workers 2 --threads 2 --timeout 120 --max-requests 1000 --max-requests-jitter 50 --log-level info --error-logfile - flask_app:app
 EXPOSE 5021

--- a/Dockerfile.stg
+++ b/Dockerfile.stg
@@ -9,5 +9,5 @@ COPY --chown=sanskrit:appgroup templates /app/templates
 COPY --chown=sanskrit:appgroup ./*.py /app/
 COPY --chown=sanskrit:appgroup ./VERSION /app/
 USER sanskrit
-CMD gunicorn --bind 0.0.0.0:5021 --workers 2 --threads 2 --timeout 120 --max-requests 1000 --max-requests-jitter 50 --log-level info --error-logfile - flask_app:app
+CMD gunicorn --bind 0.0.0.0:5021 --workers 2 --threads 5 --timeout 120 --max-requests 1000 --max-requests-jitter 50 --log-level info --error-logfile - flask_app:app
 EXPOSE 5021

--- a/IR_tools.py
+++ b/IR_tools.py
@@ -153,13 +153,6 @@ ex_doc_ids = ['NBhū_104,6^1', 'SŚP_2.21', 'MV_1,i_5,i^1']
 
 disallowed_fulltexts = ['PVin','HB','PSṬ','NV']
 
-# save fresh doc_id list to file
-doc_id_list_relative_path_fn = 'assets/doc_id_list.txt'
-doc_id_list_full_fn = os.path.join(CURRENT_FOLDER, doc_id_list_relative_path_fn)
-with open(doc_id_list_full_fn,'w') as f_out:
-    f_out.write('\n'.join(doc_ids))
-
-
 def parse_complex_doc_id(doc_id):
 # NB: returns only first original doc id from any resizing modifications
     if doc_id is None:
@@ -361,6 +354,23 @@ def get_text_view(text_abbreviation):
 
 
 ##########################################################
+# pre-build normalized theta matrix for vectorized similarity
+##########################################################
+
+# Build matrix where row i corresponds to doc_ids[i]
+theta_matrix = np.array([thetas[doc_id] for doc_id in doc_ids])
+# Pre-compute norms; set zero-norm rows (empty docs) to 1 to avoid division by zero
+_norms = np.linalg.norm(theta_matrix, axis=1, keepdims=True)
+_norms[_norms == 0] = 1.0
+theta_matrix_normed = theta_matrix / _norms
+
+# Mask for non-empty docs (used to zero out empty doc scores)
+_nonempty_mask = np.array([doc_fulltext[doc_id] != '' for doc_id in doc_ids])
+
+# Index lookup for doc_ids
+_doc_id_to_idx = {doc_id: i for i, doc_id in enumerate(doc_ids)}
+
+##########################################################
 # various functions for interface modes (docExplore etc.)
 ##########################################################
 
@@ -391,17 +401,19 @@ def rank_all_candidates_by_topic_similarity(query_id):
 
     if doc_fulltext[query_id] == '': return {}
 
-    query_vector = np.array(thetas[query_id])
-    topic_similiarity_score = {} # e.g. topic_similiarity_score[DOC_ID] = FLOAT
-    for doc_id in doc_ids:
-        candidate_vector = np.array(thetas[doc_id])
-        # use doc_fulltext to check if empty bc exact empty theta vector depends on alpha type (asymmetric etc.)
-        if doc_fulltext[doc_id] == '':
-            topic_similiarity_score[doc_id] = 0
-        else:
-            topic_similiarity_score[doc_id] = round(1-fastdist.cosine(query_vector, candidate_vector), 4)
+    idx = _doc_id_to_idx[query_id]
+    # Single matrix-vector dot product: all cosine similarities at once
+    scores = theta_matrix_normed @ theta_matrix_normed[idx]
+    # Zero out empty docs
+    scores = np.where(_nonempty_mask, scores, 0.0)
+    # Round to 4 decimal places
+    scores = np.round(scores, 4)
 
-    topic_similiarity_score.pop(query_id) # remove query itself
+    topic_similiarity_score = {
+        doc_id: float(scores[i])
+        for i, doc_id in enumerate(doc_ids)
+        if doc_id != query_id
+    }
 
     # return sorted dict in descending order by value
     sorted_results = sort_score_dict(topic_similiarity_score)
@@ -626,12 +638,20 @@ def truncate_dict(dictionary: Dict, n: int) -> Dict:
 
 N_TDIDF_SAVE_LIMIT = 2500
 N_SW_SAVE_LIMIT = 500
+
+_closest_docs_cache = {}
+
 def get_closest_docs_with_db(
         similarity_data: PymongoCollection,
         query_id,
         N_tfidf=N_TDIDF_SAVE_LIMIT,
         N_sw=N_SW_SAVE_LIMIT,
     ) -> Dict[str, Dict[str, float]]:
+
+    cache_key = (query_id, N_tfidf, N_sw)
+    if cache_key in _closest_docs_cache:
+        return _closest_docs_cache[cache_key]
+
     # start = datetime.now().time()
     if not (
             record := similarity_data.find_one({"query_id": query_id})
@@ -713,6 +733,7 @@ def get_closest_docs_with_db(
         upsert=True
     )
 
+    _closest_docs_cache[cache_key] = similar_docs
     return similar_docs
 
 
@@ -1348,53 +1369,7 @@ def compare_doc_pair(   doc_id_1, doc_id_2,
     # print("do actual overall alignment:", calc_dur(start1, datetime.now().time()))
     # print("overall:", calc_dur(start0, datetime.now().time()))
 
-    # also prepare similar_doc_links
-    # start1 = datetime.now().time()
-
-    common_kwargs = {
-        "topic_labels": topic_labels,
-        "selected_texts": selected_texts,
-        "N_tf_idf": N_tf_idf,
-        "N_sw_w": N_sw_w,
-        "results_as_links_only": True,
-        "similarity_data": similarity_data,
-    }
-    similar_doc_links_for_1 = get_closest_docs(doc_id_1, **common_kwargs)
-    similar_doc_links_for_2 = get_closest_docs(doc_id_2, **common_kwargs)
-
-    # print("prepare similar_doc_links:", calc_dur(start1, datetime.now().time()))
-    # print("overall:", calc_dur(start0, datetime.now().time()))
-
-    # make similar doc buttons show up and populate
-    # also anticipate needing numerical position in (ordered) dict (see index() below)
-    # start1 = datetime.now().time()
-
-    if doc_id_2 in similar_doc_links_for_1: # then want buttons to show up on right
-        activate_similar_link_buttons_right = 1
-        ks_1 = list(similar_doc_links_for_1.keys())
-        prev_sim_doc_id_for_1 = similar_doc_links_for_1[doc_id_2]['prev']
-        next_sim_doc_id_for_1 = similar_doc_links_for_1[doc_id_2]['next']
-        sim_rank_of_prev_for_1 = ks_1.index(prev_sim_doc_id_for_1) + 1 if prev_sim_doc_id_for_1 else None
-        sim_rank_of_2_for_1 = ks_1.index(doc_id_2) + 1
-        sim_rank_of_next_for_1 = ks_1.index(next_sim_doc_id_for_1) + 1 if next_sim_doc_id_for_1 else None
-    else:
-        activate_similar_link_buttons_right = ""
-        prev_sim_doc_id_for_1 = next_sim_doc_id_for_1 = sim_rank_of_prev_for_1 = sim_rank_of_2_for_1 = sim_rank_of_next_for_1 = ""
-
-    if doc_id_1 in similar_doc_links_for_2: # then want buttons to show up on left
-        activate_similar_link_buttons_left = 1
-        ks_2 = list(similar_doc_links_for_2.keys())
-        prev_sim_doc_id_for_2 = similar_doc_links_for_2[doc_id_1]['prev']
-        next_sim_doc_id_for_2 = similar_doc_links_for_2[doc_id_1]['next']
-        sim_rank_of_prev_for_2 = ks_2.index(prev_sim_doc_id_for_2) + 1 if prev_sim_doc_id_for_2 else None
-        sim_rank_of_1_for_2 = ks_2.index(doc_id_1) + 1
-        sim_rank_of_next_for_2 = ks_2.index(next_sim_doc_id_for_2) + 1 if next_sim_doc_id_for_2 else None
-    else:
-        activate_similar_link_buttons_left = ""
-        prev_sim_doc_id_for_2 = next_sim_doc_id_for_2 = sim_rank_of_prev_for_2 = sim_rank_of_1_for_2 = sim_rank_of_next_for_2 = ""
-
-    # print("make similar doc buttons show up and populate:", calc_dur(start1, datetime.now().time()))
-    # print("overall:", calc_dur(start0, datetime.now().time()))
+    # similar_doc_links now loaded via AJAX in the template
 
     # format HTML results
     # start1 = datetime.now().time()
@@ -1425,17 +1400,17 @@ def compare_doc_pair(   doc_id_1, doc_id_2,
                     last_doc_id_1=get_full_local_doc_id(doc_links[doc_id_1]['last']),
                     last_doc_id_2=get_full_local_doc_id(doc_links[doc_id_2]['last']),
 
-                    prev_sim_doc_id_for_2=prev_sim_doc_id_for_2, # left
-                    next_sim_doc_id_for_2=next_sim_doc_id_for_2,
-                    sim_rank_of_prev_for_2=sim_rank_of_prev_for_2,
-                    sim_rank_of_1_for_2=sim_rank_of_1_for_2,
-                    sim_rank_of_next_for_2=sim_rank_of_next_for_2,
+                    prev_sim_doc_id_for_2="", # left (populated via AJAX)
+                    next_sim_doc_id_for_2="",
+                    sim_rank_of_prev_for_2="",
+                    sim_rank_of_1_for_2="",
+                    sim_rank_of_next_for_2="",
 
-                    prev_sim_doc_id_for_1=prev_sim_doc_id_for_1, # right
-                    next_sim_doc_id_for_1=next_sim_doc_id_for_1,
-                    sim_rank_of_prev_for_1=sim_rank_of_prev_for_1,
-                    sim_rank_of_2_for_1=sim_rank_of_2_for_1,
-                    sim_rank_of_next_for_1=sim_rank_of_next_for_1,
+                    prev_sim_doc_id_for_1="", # right (populated via AJAX)
+                    next_sim_doc_id_for_1="",
+                    sim_rank_of_prev_for_1="",
+                    sim_rank_of_2_for_1="",
+                    sim_rank_of_next_for_1="",
 
                     N_sw_w=N_sw_w,
 
@@ -1460,7 +1435,7 @@ def compare_doc_pair(   doc_id_1, doc_id_2,
     # print("format HTML results:", calc_dur(start1, datetime.now().time()))
     # print("overall:", calc_dur(start0, datetime.now().time()))
 
-    return results_HTML, activate_similar_link_buttons_left, activate_similar_link_buttons_right
+    return results_HTML
 
 
 

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-__app_version__ = "1.2.3"
+__app_version__ = "1.3.0"

--- a/assets/robots.txt
+++ b/assets/robots.txt
@@ -1,3 +1,11 @@
 User-agent: *
+Disallow: /docExplore
 Disallow: /docCompare
+Disallow: /textView
+Disallow: /textSelect
+Disallow: /topicAdjust
+Disallow: /searchDepth
+Disallow: /topicVisualizeLDAvis
+Disallow: /BrucheionAlign
 Disallow: /assets/
+Disallow: /api/

--- a/flask_app.py
+++ b/flask_app.py
@@ -501,6 +501,9 @@ def api_similar_doc_links():
     if not doc_id or doc_id not in IR_tools.doc_ids:
         return jsonify({'error': 'invalid doc_id'}), 400
 
+    if not similarity_data.find_one({"query_id": doc_id}, {"_id": 1}):
+        return jsonify({'found': False})
+
     similar_doc_links = IR_tools.get_closest_docs(
         query_id=doc_id,
         topic_labels=session['topic_labels'],

--- a/flask_app.py
+++ b/flask_app.py
@@ -1,8 +1,9 @@
 import logging
 import os
 import html
+from functools import wraps
 
-from flask import Flask, session, redirect, render_template, request, url_for, send_from_directory, abort
+from flask import Flask, session, redirect, render_template, request, url_for, send_from_directory, abort, Response, jsonify
 from flask_pymongo import PyMongo
 
 import IR_tools
@@ -17,7 +18,7 @@ app = Flask(__name__)
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-app.config["DEBUG"] = True
+app.config["DEBUG"] = os.getenv("FLASK_DEBUG", "0") == "1"
 app.config["SECRET_KEY"] = "safaksdfakjdshfkajshfka" # for session, no actual need for secrecy
 DB_SERVER = os.getenv("DB_SERVER", "localhost")
 app.config["MONGO_URI"] = f"mongodb://{DB_SERVER}:27017/vatayana"
@@ -42,12 +43,37 @@ def serve_files(name):
 def robots_txt():
     return send_from_directory('assets', 'robots.txt')
 
+def require_auth(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        auth = request.authorization
+        if not auth or auth.username != 'guest' or auth.password != 'guest':
+            body = (
+                '<html><body style="font-family:sans-serif;padding:2em;max-width:480px;margin:auto;">'
+                '<h2>docCompare requires a login</h2>'
+                '<p>This is just to keep bots out.</p>'
+                '<p>Username: <code>guest</code><br>Password: <code>guest</code></p>'
+                '<p><a href="">Click here to try again</a></p>'
+                '</body></html>'
+            )
+            return Response(
+                body,
+                401,
+                {'WWW-Authenticate': 'Basic realm="docCompare"',
+                 'Content-Type': 'text/html; charset=utf-8'}
+            )
+        return f(*args, **kwargs)
+    return decorated
+
 @app.before_request
 def block_bots():
-    botlist = ['Amazonbot', 'Bytespider']
-    user_agent = request.headers.get('User-Agent')
+    botlist = [
+        'Amazonbot', 'Bytespider', 'GPTBot', 'ChatGPT-User', 'CCBot',
+        'Google-Extended', 'ClaudeBot', 'anthropic-ai', 'Applebot-Extended',
+        'FacebookBot', 'Meta-ExternalAgent', 'PerplexityBot', 'Cohere-ai',
+    ]
+    user_agent = request.headers.get('User-Agent', '')
     if any(bot in user_agent for bot in botlist):
-        # logger.debug("Bot blocked", extra={'agent': user_agent, 'path': request.path})
         abort(403)
     else:
         logger.info("Request handled", extra={'path': request.path, 'method': request.method, 'ip': request.remote_addr})
@@ -206,9 +232,6 @@ def doc_explore():
                                 local_doc_id=local_doc_id,
                                 local_doc_id_2=local_doc_id_2,
                                 docExploreInner_HTML=docExploreInner_HTML,
-                                abbrv2docs=IR_tools.abbrv2docs,
-                                text_abbrev2title=IR_tools.text_abbrev2title,
-                                section_labels=IR_tools.section_labels,
                                 sw_threshold=sw_threshold,
                                 )
 
@@ -218,12 +241,10 @@ def doc_explore():
                                 page_subtitle="docExplore",
                                 doc_id="",
                                 doc_explore_output="",
-                                abbrv2docs=IR_tools.abbrv2docs,
-                                text_abbrev2title=IR_tools.text_abbrev2title,
-                                section_labels=IR_tools.section_labels,
                                 )
 
 @app.route('/docCompare', methods=["GET", "POST"])
+@require_auth
 def doc_compare():
 
     ensure_keys()
@@ -246,12 +267,11 @@ def doc_compare():
             doc_id_2 = text_abbreviation_2 + '_' + local_doc_id_2
 
         valid_doc_ids = IR_tools.doc_ids
-        sim_btn_left = sim_btn_right = ""
         if doc_id_1 == doc_id_2:
             docCompareInner_HTML = "<br><p>Those are the same, please enter two different doc ids to compare.</p>"
         elif doc_id_1 in valid_doc_ids and doc_id_2 in valid_doc_ids:
 
-            docCompareInner_HTML, sim_btn_left, sim_btn_right = IR_tools.compare_doc_pair(
+            docCompareInner_HTML = IR_tools.compare_doc_pair(
                 doc_id_1,
                 doc_id_2,
                 topic_labels=session['topic_labels'],
@@ -271,12 +291,7 @@ def doc_compare():
                                 text_abbreviation_2=text_abbreviation_2,
                                 local_doc_id_1=local_doc_id_1,
                                 local_doc_id_2=local_doc_id_2,
-                                activate_similar_link_buttons_left=sim_btn_left,
-                                activate_similar_link_buttons_right=sim_btn_right,
                                 docCompareInner_HTML=docCompareInner_HTML,
-                                abbrv2docs=IR_tools.abbrv2docs,
-                                text_abbrev2title=IR_tools.text_abbrev2title,
-                                section_labels=IR_tools.section_labels,
                                 )
 
     else: # request.method == "GET" or URL query malformed
@@ -285,10 +300,11 @@ def doc_compare():
                                 page_subtitle="docCompare",
                                 doc_id_1="",
                                 doc_id_2="",
+                                text_abbreviation_1="",
+                                text_abbreviation_2="",
+                                local_doc_id_1="",
+                                local_doc_id_2="",
                                 doc_explore_output="",
-                                abbrv2docs=IR_tools.abbrv2docs,
-                                text_abbrev2title=IR_tools.text_abbrev2title,
-                                section_labels=IR_tools.section_labels,
                                 )
 
 @app.route('/textView', methods=["GET", "POST"])
@@ -329,9 +345,6 @@ def text_view():
                                 local_doc_id=local_doc_id,
                                 text_title=text_title,
                                 text_HTML=text_HTML,
-                                abbrv2docs=IR_tools.abbrv2docs,
-                                text_abbrev2title=IR_tools.text_abbrev2title,
-                                section_labels=IR_tools.section_labels,
                                 )
 
     else: # request.method == "GET" or no URL params
@@ -342,9 +355,6 @@ def text_view():
                                 local_doc_id="",
                                 text_title="",
                                 text_HTML="",
-                                abbrv2docs=IR_tools.abbrv2docs,
-                                text_abbrev2title=IR_tools.text_abbrev2title,
-                                section_labels=IR_tools.section_labels,
                                 )
 
 @app.route('/BrucheionAlign')
@@ -433,8 +443,6 @@ def text_select():
     return render_template(    "textSelect.html",
                             page_subtitle="textSelect",
                             textSelectInner_HTML=textSelectInner_HTML,
-                            abbrv2docs=IR_tools.abbrv2docs,
-                            text_abbrev2title=IR_tools.text_abbrev2title,
                             )
 
 
@@ -466,6 +474,63 @@ def search_depth():
                             page_subtitle="searchDepth",
                             searchDepthInner_HTML=searchDepthInner_HTML
                             )
+
+@app.route('/api/section_labels.json')
+def api_section_labels():
+    resp = jsonify(IR_tools.section_labels)
+    resp.headers['Cache-Control'] = 'public, max-age=86400'
+    return resp
+
+@app.route('/api/abbrv2docs.json')
+def api_abbrv2docs():
+    resp = jsonify(IR_tools.abbrv2docs)
+    resp.headers['Cache-Control'] = 'public, max-age=86400'
+    return resp
+
+@app.route('/api/abbrev2title.json')
+def api_abbrev2title():
+    resp = jsonify(IR_tools.text_abbrev2title)
+    resp.headers['Cache-Control'] = 'public, max-age=86400'
+    return resp
+
+@app.route('/api/similar_doc_links')
+def api_similar_doc_links():
+    ensure_keys()
+    doc_id = request.args.get('doc_id')
+    other_doc_id = request.args.get('other_doc_id')
+    if not doc_id or doc_id not in IR_tools.doc_ids:
+        return jsonify({'error': 'invalid doc_id'}), 400
+
+    similar_doc_links = IR_tools.get_closest_docs(
+        query_id=doc_id,
+        topic_labels=session['topic_labels'],
+        selected_texts=session['selected_texts'],
+        N_tf_idf=session['N_tf_idf'],
+        N_sw_w=session['N_sw_w'],
+        results_as_links_only=True,
+        similarity_data=similarity_data,
+    )
+
+    if other_doc_id and other_doc_id in similar_doc_links:
+        ks = list(similar_doc_links.keys())
+        entry = similar_doc_links[other_doc_id]
+        rank = ks.index(other_doc_id) + 1
+        prev_id = entry['prev']
+        next_id = entry['next']
+        prev_rank = (ks.index(prev_id) + 1) if prev_id else None
+        next_rank = (ks.index(next_id) + 1) if next_id else None
+        return jsonify({
+            'found': True,
+            'rank': rank,
+            'total': session['N_sw_w'],
+            'prev_doc_id': prev_id,
+            'next_doc_id': next_id,
+            'prev_rank': prev_rank,
+            'next_rank': next_rank,
+        })
+    else:
+        return jsonify({'found': False})
+
 
 if __name__ == '__main__':
     app.run(debug=True, port=5020)

--- a/templates/docCompare.html
+++ b/templates/docCompare.html
@@ -74,13 +74,20 @@
         </div><!-- container -->
 
         <script>
-        	function loadSimilarDocNav(queryDocId, otherDocId, side) {
+        	function loadSimilarDocNav(queryDocId, otherDocId, side, attempt) {
+                attempt = attempt || 1;
                 var simNav = document.getElementById('sim-nav-' + side);
                 if (!simNav || !queryDocId || !otherDocId) return;
                 fetch('/api/similar_doc_links?doc_id=' + encodeURIComponent(queryDocId) + '&other_doc_id=' + encodeURIComponent(otherDocId))
-                    .then(function(r) { return r.json(); })
+                    .then(function(r) {
+                        if (r.status === 503 && attempt < 4) {
+                            setTimeout(function() { loadSimilarDocNav(queryDocId, otherDocId, side, attempt + 1); }, attempt * 1000);
+                            return null;
+                        }
+                        return r.json();
+                    })
                     .then(function(data) {
-                        if (!data.found) return;
+                        if (!data || !data.found) return;
                         simNav.dataset.rank = data.rank;
                         simNav.dataset.total = data.total;
 

--- a/templates/docCompare.html
+++ b/templates/docCompare.html
@@ -126,14 +126,6 @@
             }
 
          	window.onload = function() {
-                var doc1 = "{{ doc_id_1 }}";
-                var doc2 = "{{ doc_id_2 }}";
-                if (doc1 && doc2) {
-                    // left side: doc2's similar docs, checking if doc1 is among them
-                    loadSimilarDocNav(doc2, doc1, 'left');
-                    // right side: doc1's similar docs, checking if doc2 is among them
-                    loadSimilarDocNav(doc1, doc2, 'right');
-                }
 
               // ─── DOCUMENT NAVIGATION: first/prev/next/last for left & right ─────────────────
 			  ['left','right'].forEach(side => {
@@ -166,6 +158,8 @@
 			var abbrv2docs = {};
 			var abbrev2title = {};
 			var section_labels = {};
+			var doc1 = "{{ doc_id_1 }}";
+			var doc2 = "{{ doc_id_2 }}";
 
 			var initial_values = [
 				{
@@ -227,6 +221,10 @@
 				section_labels = results[2];
 				for (var pair of initial_values) {
 					setupSelectorPair(pair.textSelId, pair.docSelId, pair.text_abbreviation, pair.local_doc_id);
+				}
+				if (doc1 && doc2) {
+					loadSimilarDocNav(doc2, doc1, 'left');
+					loadSimilarDocNav(doc1, doc2, 'right');
 				}
 			});
         </script>

--- a/templates/docCompare.html
+++ b/templates/docCompare.html
@@ -154,37 +154,6 @@
 				});
 			  });
 
-			  // ─── SIMILARITY NAVIGATION: for left & right ─────────────────────────────────────
-			  ['left','right'].forEach(side => {
-				const simNav = document.getElementById(`sim-nav-${side}`);
-				if (!simNav) return;
-
-				const rank  = parseInt(simNav.dataset.rank,  10) || 0;
-				const total = parseInt(simNav.dataset.total, 10) || 0;
-
-				// always show the row
-				simNav.style.display = '';
-
-				// hide entire row if invalid rank
-				if (rank < 1 || rank > total) {
-				  simNav.style.display = 'none';
-				  return;
-				}
-
-				// hide the “more similar” button at rank 1
-				const btnPrev = document.getElementById(`sim-prev-btn-${side}`);
-				if (rank === 1 && btnPrev) {
-				  btnPrev.disabled = true;
-				  btnPrev.classList.add('disabled');
-				}
-
-				// hide the “less similar” button at rank=total
-				const btnNext = document.getElementById(`sim-next-btn-${side}`);
-				if (rank === total && btnNext) {
-				  btnNext.disabled = true;
-				  Next.classList.add('disabled');
-				}
-			  });
             }
 
 			var abbrv2docs = {};

--- a/templates/docCompare.html
+++ b/templates/docCompare.html
@@ -116,8 +116,7 @@
                         // Update rank text
                         var rankText = simNav.querySelector('.text-center small');
                         if (rankText) {
-                            var forDoc = side === 'left' ? otherDocId : otherDocId;
-                            rankText.innerHTML = 'for <em>' + forDoc + '</em>:<br>most similar #' + data.rank + ' of ' + data.total;
+                            rankText.innerHTML = 'for <em>' + queryDocId + '</em>:<br>most similar #' + data.rank + ' of ' + data.total;
                         }
 
                         simNav.style.visibility = 'visible';

--- a/templates/docCompare.html
+++ b/templates/docCompare.html
@@ -115,7 +115,7 @@
 
                         simNav.style.visibility = 'visible';
                     })
-                    .catch(function() {});
+                    .catch(function(e) { console.error('sim-nav-' + side + ' error:', e); });
             }
 
          	window.onload = function() {

--- a/templates/docCompare.html
+++ b/templates/docCompare.html
@@ -74,19 +74,59 @@
         </div><!-- container -->
 
         <script>
-        	function conditionally_display_similar_doc_link_buttons() {
-                sim_btn_left = "{{ activate_similar_link_buttons_left }}";
-                if ( sim_btn_left.length > 0 ) {
-                    document.getElementById("sim-nav-left").style.visibility = "visible";
-                }
-                sim_btn_right = "{{ activate_similar_link_buttons_right }}";
-                if ( sim_btn_right.length > 0 ) {
-                    document.getElementById("sim-nav-right").style.visibility = "visible";
-                }
+        	function loadSimilarDocNav(queryDocId, otherDocId, side) {
+                var simNav = document.getElementById('sim-nav-' + side);
+                if (!simNav || !queryDocId || !otherDocId) return;
+                fetch('/api/similar_doc_links?doc_id=' + encodeURIComponent(queryDocId) + '&other_doc_id=' + encodeURIComponent(otherDocId))
+                    .then(function(r) { return r.json(); })
+                    .then(function(data) {
+                        if (!data.found) return;
+                        simNav.dataset.rank = data.rank;
+                        simNav.dataset.total = data.total;
+
+                        // Update button form values
+                        var prevBtn = document.getElementById('sim-prev-btn-' + side);
+                        var nextBtn = document.getElementById('sim-next-btn-' + side);
+                        if (prevBtn) {
+                            var prevInput = prevBtn.closest('form').querySelector('input[name="doc_id_' + (side === 'left' ? '1' : '2') + '"]');
+                            if (prevInput) prevInput.value = data.prev_doc_id || '';
+                            prevBtn.title = 'More similar (#' + (data.prev_rank || '') + ' of ' + data.total + ')';
+                            if (!data.prev_doc_id || data.rank === 1) {
+                                prevBtn.disabled = true;
+                                prevBtn.classList.add('disabled');
+                            }
+                        }
+                        if (nextBtn) {
+                            var nextInput = nextBtn.closest('form').querySelector('input[name="doc_id_' + (side === 'left' ? '1' : '2') + '"]');
+                            if (nextInput) nextInput.value = data.next_doc_id || '';
+                            nextBtn.title = 'Less similar (#' + (data.next_rank || '') + ' of ' + data.total + ')';
+                            if (!data.next_doc_id || data.rank === data.total) {
+                                nextBtn.disabled = true;
+                                nextBtn.classList.add('disabled');
+                            }
+                        }
+
+                        // Update rank text
+                        var rankText = simNav.querySelector('.text-center small');
+                        if (rankText) {
+                            var forDoc = side === 'left' ? otherDocId : otherDocId;
+                            rankText.innerHTML = 'for <em>' + forDoc + '</em>:<br>most similar #' + data.rank + ' of ' + data.total;
+                        }
+
+                        simNav.style.visibility = 'visible';
+                    })
+                    .catch(function() {});
             }
 
          	window.onload = function() {
-                conditionally_display_similar_doc_link_buttons();
+                var doc1 = "{{ doc_id_1 }}";
+                var doc2 = "{{ doc_id_2 }}";
+                if (doc1 && doc2) {
+                    // left side: doc2's similar docs, checking if doc1 is among them
+                    loadSimilarDocNav(doc2, doc1, 'left');
+                    // right side: doc1's similar docs, checking if doc2 is among them
+                    loadSimilarDocNav(doc1, doc2, 'right');
+                }
 
               // ─── DOCUMENT NAVIGATION: first/prev/next/last for left & right ─────────────────
 			  ['left','right'].forEach(side => {
@@ -147,9 +187,9 @@
 			  });
             }
 
-			var abbrv2docs = {{ abbrv2docs|tojson|safe }};
-			var abbrev2title = {{ text_abbrev2title|tojson|safe }};
-			var section_labels = {{ section_labels|tojson|safe }};
+			var abbrv2docs = {};
+			var abbrev2title = {};
+			var section_labels = {};
 
 			var initial_values = [
 				{
@@ -200,10 +240,19 @@
 				};
 			}
 
-			// --- Apply to both pairs ---
-			for (var pair of initial_values) {
-				setupSelectorPair(pair.textSelId, pair.docSelId, pair.text_abbreviation, pair.local_doc_id);
-			}
+			// --- Fetch data from API, then apply to both pairs ---
+			Promise.all([
+				fetch('/api/abbrv2docs.json').then(function(r) { return r.json(); }),
+				fetch('/api/abbrev2title.json').then(function(r) { return r.json(); }),
+				fetch('/api/section_labels.json').then(function(r) { return r.json(); }),
+			]).then(function(results) {
+				abbrv2docs = results[0];
+				abbrev2title = results[1];
+				section_labels = results[2];
+				for (var pair of initial_values) {
+					setupSelectorPair(pair.textSelId, pair.docSelId, pair.text_abbreviation, pair.local_doc_id);
+				}
+			});
         </script>
 
     </body>

--- a/templates/docExplore.html
+++ b/templates/docExplore.html
@@ -116,9 +116,9 @@
 			});
 		}
 
-    	var abbrv2docs = {{ abbrv2docs|tojson|safe }};
-		var abbrev2title = {{ text_abbrev2title|tojson|safe }};
-		var section_labels = {{ section_labels|tojson|safe }};
+    	var abbrv2docs = {};
+		var abbrev2title = {};
+		var section_labels = {};
 
 		var initial_values = {
 			text_abbreviation: "{{ text_abbreviation }}",
@@ -196,15 +196,24 @@
 			}
 		}
 
-		// --- Apply to the trio of dropdowns ---
-		setupSelectorTrio(
-			initial_values.textSelId,
-			initial_values.docSelId,
-			initial_values.docSelId2,
-			initial_values.text_abbreviation,
-			initial_values.local_doc_id,
-			initial_values.local_doc_id_2
-		);
+		// --- Fetch data from API, then apply to the trio of dropdowns ---
+		Promise.all([
+			fetch('/api/abbrv2docs.json').then(r => r.json()),
+			fetch('/api/abbrev2title.json').then(r => r.json()),
+			fetch('/api/section_labels.json').then(r => r.json()),
+		]).then(([a2d, a2t, sl]) => {
+			abbrv2docs = a2d;
+			abbrev2title = a2t;
+			section_labels = sl;
+			setupSelectorTrio(
+				initial_values.textSelId,
+				initial_values.docSelId,
+				initial_values.docSelId2,
+				initial_values.text_abbreviation,
+				initial_values.local_doc_id,
+				initial_values.local_doc_id_2
+			);
+		});
 
     </script>
 

--- a/templates/textSelect.html
+++ b/templates/textSelect.html
@@ -37,14 +37,19 @@
     </body>
 
     <script type="text/javascript">
-    	var abbrv2docs = {{ abbrv2docs|tojson|safe }};
-    	var abbrev2title = {{ text_abbrev2title|tojson|safe }};
+		Promise.all([
+			fetch('/api/abbrv2docs.json').then(function(r) { return r.json(); }),
+			fetch('/api/abbrev2title.json').then(function(r) { return r.json(); }),
+		]).then(function(results) {
+			var abbrv2docs = results[0];
+			var abbrev2title = results[1];
 
-		var textAbbrevSel = document.getElementById("select_one_text_text_input");
-		textAbbrevSel.length = 1;
-		for (var x in abbrv2docs) {
-			textAbbrevSel.options[textAbbrevSel.options.length] = new Option(x + ' ' + abbrev2title[x], x);
-		}
+			var textAbbrevSel = document.getElementById("select_one_text_text_input");
+			textAbbrevSel.length = 1;
+			for (var x in abbrv2docs) {
+				textAbbrevSel.options[textAbbrevSel.options.length] = new Option(x + ' ' + abbrev2title[x], x);
+			}
+		});
     </script>
 
 

--- a/templates/textView.html
+++ b/templates/textView.html
@@ -53,22 +53,29 @@
     </body>
 
     <script type="text/javascript">
-    	var abbrv2docs = {{ abbrv2docs|tojson|safe }};
-    	var abbrev2title = {{ text_abbrev2title|tojson|safe }};
-    	var section_labels = {{ section_labels|tojson|safe }};
-
 		var textAbbrevSel = document.getElementById("text_abbreviation_input");
 		var docIdSel = document.getElementById("local_doc_id_input");
-		textAbbrevSel.length = 1;
-		for (var x in abbrv2docs) {
-			textAbbrevSel.options[textAbbrevSel.options.length] = new Option(x + ' ' + abbrev2title[x], x);
-		}
-		textAbbrevSel.onchange = function() {		    
-			docIdSel.length = 1;
-			for (var y of abbrv2docs[this.value]) {
-			  docIdSel.options[docIdSel.options.length] = new Option(y + ' ' + section_labels[this.value + '_' + y], y);
+
+		Promise.all([
+			fetch('/api/abbrv2docs.json').then(function(r) { return r.json(); }),
+			fetch('/api/abbrev2title.json').then(function(r) { return r.json(); }),
+			fetch('/api/section_labels.json').then(function(r) { return r.json(); }),
+		]).then(function(results) {
+			var abbrv2docs = results[0];
+			var abbrev2title = results[1];
+			var section_labels = results[2];
+
+			textAbbrevSel.length = 1;
+			for (var x in abbrv2docs) {
+				textAbbrevSel.options[textAbbrevSel.options.length] = new Option(x + ' ' + abbrev2title[x], x);
 			}
-		}
+			textAbbrevSel.onchange = function() {
+				docIdSel.length = 1;
+				for (var y of abbrv2docs[this.value]) {
+				  docIdSel.options[docIdSel.options.length] = new Option(y + ' ' + section_labels[this.value + '_' + y], y);
+				}
+			}
+		});
     </script>
 
 </html>


### PR DESCRIPTION
(Calling this a minor update because the addition of Basic Auth in exchange to have the app not crash all the time feels significant.)

## Summary

Performance rescue for the vatayana server. Bots crawling `/docCompare`'s ~400M URL pairs were overwhelming the single-worker gunicorn with expensive NLP computations (Smith-Waterman alignment + ColateX collation + full similarity pipelines). This PR addresses the problem from multiple angles:

### Bot protection
- **HTTP Basic Auth on `/docCompare`** — trivial guest/guest credentials with a fallback hint page. Bots get 401 and stop. Browsers cache credentials for the session, so humans authenticate once.
- **Expanded bot blocklist** — from 2 to 13 known AI/scraper bots (GPTBot, ChatGPT-User, CCBot, ClaudeBot, PerplexityBot, etc.)
- **robots.txt** — now disallows all dynamic routes (`/docExplore`, `/docCompare`, `/textView`, `/textSelect`, `/topicAdjust`, `/searchDepth`, `/topicVisualizeLDAvis`, `/BrucheionAlign`, `/api/`)

### Performance — topic similarity vectorization
- **Before:** `rank_all_candidates_by_topic_similarity()` iterated over all 28,381 docs in a Python loop, calling `fastdist.cosine()` individually (~0.86s)
- **After:** Pre-built normalized theta matrix (28381×75) at module load; single `theta_matrix_normed @ theta_matrix_normed[idx]` dot product (~0.01s)

### Performance — lazy-load similarity nav in docCompare
- Removed the two `get_closest_docs()` calls from `compare_doc_pair()` — these were running full similarity pipelines just to populate prev/next nav buttons
- New `/api/similar_doc_links` AJAX endpoint loads this data asynchronously after the page renders
- `compare_doc_pair()` now returns just HTML instead of a 3-tuple
- Fixed: removed a redundant synchronous `forEach` block that ran at `window.onload` before the fetch could return, hiding the nav and overriding the AJAX result (also had a `Next` → `btnNext` typo that would have thrown a ReferenceError)
- Fixed: `forDoc` label in rank text was `otherDocId` on both sides (broken ternary); corrected to `queryDocId` to properly reflect the chiasmus at the call site
- `/api/similar_doc_links` now returns `found: false` immediately if the doc has no MongoDB record, avoiding live NLP computation in the AJAX path
- `similar_doc_links` AJAX calls are now fired sequentially after the `Promise.all` for the JSON endpoints resolves, rather than simultaneously — keeps peak concurrency at 3 requests instead of 5, avoiding worker saturation

### Performance — in-memory result cache
- `get_closest_docs_with_db()` results cached in a dict keyed on `(query_id, N_tfidf, N_sw)`. Corpus is static, so repeated queries and the AJAX nav endpoint hit cache.

### Performance — cacheable JSON API endpoints
- New endpoints: `/api/section_labels.json`, `/api/abbrv2docs.json`, `/api/abbrev2title.json` with `Cache-Control: public, max-age=86400`
- All 4 templates (`docExplore`, `docCompare`, `textView`, `textSelect`) now fetch these via AJAX instead of receiving ~1.5MB of inline JSON per page load

### Infrastructure
- **Gunicorn:** `--workers 2 --threads 5 --timeout 120 --max-requests 1000 --max-requests-jitter 50`
- **DEBUG:** now `os.getenv("FLASK_DEBUG", "0") == "1"` instead of hardcoded `True`
- Removed `doc_id_list.txt` write on startup

## Files changed

| File | Changes |
|------|---------|
| `flask_app.py` | Auth decorator, JSON API endpoints, AJAX similar-doc-links endpoint (with MongoDB short-circuit), expanded bot list, env-based DEBUG, removed inline JSON from template contexts |
| `IR_tools.py` | Vectorized topic similarity matrix, in-memory cache, removed `get_closest_docs` calls from `compare_doc_pair`, removed doc_id_list write |
| `assets/robots.txt` | Disallow all dynamic routes |
| `Dockerfile` | gunicorn workers/threads/timeout/max-requests |
| `Dockerfile.stg` | Same |
| `templates/docExplore.html` | Fetch section_labels + abbrv2docs + abbrev2title via AJAX |
| `templates/docCompare.html` | Same + lazy-load similar-doc nav via AJAX (sequenced after JSON calls, fixed forEach race, fixed forDoc label) |
| `templates/textView.html` | Fetch via AJAX |
| `templates/textSelect.html` | Fetch via AJAX |

## Test plan

- [ ] `python -c "import IR_tools"` — module loads, vectorized matrix built
- [ ] Start dev server, visit `/docCompare?doc_id_1=NBhū_104,6^1&doc_id_2=PVin_I,034,i` — browser prompts for credentials, enter guest/guest, page loads. Refresh — no prompt (cached).
- [ ] `curl localhost:5021/docCompare` without auth → 401
- [ ] Visit `/docExplore?doc_id=NBhū_104,6^1` — no auth needed, loads fast
- [ ] Page source no longer contains 1.5MB inline JSON blobs
- [ ] Similarity nav buttons appear asynchronously on docCompare
- [ ] Dropdown selectors still populate correctly on all pages
- [ ] `curl -A "GPTBot" localhost:5021/docExplore` → 403
